### PR TITLE
Rename lab tests and update branding

### DIFF
--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -8,7 +8,7 @@ from .pages.lab_page import LabPage
 from .pages.devices_page import DevicesPage
 from .pages.results_page import ResultsPage
 
-APP_TITLE = "LatencyLab — Modular Sleek"
+APP_TITLE = "PawdioLab — Modular Sleek"
 
 class MainApp(ctk.CTk):
     def __init__(self):
@@ -20,7 +20,7 @@ class MainApp(ctk.CTk):
         self.grid_columnconfigure(1, weight=1); self.grid_rowconfigure(0, weight=1)
         self.sidebar = ctk.CTkFrame(self, corner_radius=0, width=230); self.sidebar.grid(row=0, column=0, sticky="nsw")
         self.sidebar.grid_rowconfigure(10, weight=1)
-        ctk.CTkLabel(self.sidebar, text="LatencyLab", font=ctk.CTkFont(size=20, weight="bold")).grid(row=0, column=0, padx=18, pady=(18,8), sticky="w")
+        ctk.CTkLabel(self.sidebar, text="PawdioLab", font=ctk.CTkFont(size=20, weight="bold")).grid(row=0, column=0, padx=18, pady=(18,8), sticky="w")
 
         self.btn_latency = ctk.CTkButton(self.sidebar, text="Latency", command=lambda: self._show("latency")); self.btn_latency.grid(row=2, column=0, padx=16, pady=6, sticky="ew")
         self.btn_devices = ctk.CTkButton(self.sidebar, text="Devices / Settings", command=lambda: self._show("devices")); self.btn_devices.grid(row=3, column=0, padx=16, pady=6, sticky="ew")
@@ -48,7 +48,7 @@ class MainApp(ctk.CTk):
     def _add_labs_page(self):
         self.pages["lab"] = LabPage(self.main, self.core, self.cfg, self._log)
         if self.btn_lab is None:
-            self.btn_lab = ctk.CTkButton(self.sidebar, text="Lab Tests", command=lambda: self._show("lab"))
+            self.btn_lab = ctk.CTkButton(self.sidebar, text="Experimental Tests", command=lambda: self._show("lab"))
             self.btn_lab.grid(row=5, column=0, padx=16, pady=6, sticky="ew")
 
     def _remove_labs_page(self):

--- a/app/ui/pages/devices_page.py
+++ b/app/ui/pages/devices_page.py
@@ -36,7 +36,7 @@ class DevicesPage(ctk.CTkFrame):
         self.color = ctk.CTkOptionMenu(ap, values=["blue","dark-blue","green"]); self.color.set(self.cfg["ui"].get("color_theme","blue")); self.color.grid(row=0, column=3, padx=8, sticky="w")
 
         self.labs_var = ctk.BooleanVar(value=bool(self.cfg["ui"].get("labs_enabled", True)))
-        ctk.CTkSwitch(ap, text="Enable Lab Tests (experimental)", variable=self.labs_var, command=self._toggle_labs).grid(row=1, column=0, columnspan=2, padx=8, pady=(8,6), sticky="w")
+        ctk.CTkSwitch(ap, text="Enable Experimental Tests", variable=self.labs_var, command=self._toggle_labs).grid(row=1, column=0, columnspan=2, padx=8, pady=(8,6), sticky="w")
 
         self._refresh_devices()
 

--- a/app/ui/pages/lab_page.py
+++ b/app/ui/pages/lab_page.py
@@ -10,7 +10,7 @@ class LabPage(ctk.CTkFrame):
         self.results = []
         self.grid_columnconfigure(0, weight=1); self.grid_columnconfigure(1, weight=1)
 
-        ctk.CTkLabel(self, text="Lab Tests", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, columnspan=2, padx=18, pady=(18,4), sticky="w")
+        ctk.CTkLabel(self, text="Experimental Tests", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, columnspan=2, padx=18, pady=(18,4), sticky="w")
 
         bal = ctk.CTkFrame(self); bal.grid(row=1, column=0, padx=18, pady=12, sticky="nsew")
         self.var_bal = ctk.StringVar(value="1000")
@@ -44,7 +44,7 @@ class LabPage(ctk.CTkFrame):
 
         res = ctk.CTkFrame(self); res.grid(row=3, column=1, padx=18, pady=12, sticky="nsew")
         res.grid_rowconfigure(1, weight=1); res.grid_columnconfigure(0, weight=1)
-        ctk.CTkLabel(res, text="Lab Results").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
+        ctk.CTkLabel(res, text="Experimental Results").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
         self.box = ctk.CTkTextbox(res); self.box.grid(row=1, column=0, sticky="nsew", padx=8, pady=8)
         row = ctk.CTkFrame(res); row.grid(row=2, column=0, sticky="ew", padx=8, pady=(0,8))
         ctk.CTkButton(row, text="Export LAST (JSON)", command=self.export_last).pack(side="left", padx=4)
@@ -82,7 +82,7 @@ class LabPage(ctk.CTkFrame):
         last = self.results[-1]
         import json, datetime
         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        path = os.path.join(out_dir, f"lab_last_{ts}.json")
+        path = os.path.join(out_dir, f"experimental_last_{ts}.json")
         with open(path, "w", encoding="utf-8") as f: json.dump(last, f, indent=2, ensure_ascii=False)
         self.log(f"[EXPORT] last -> {path}")
 
@@ -91,6 +91,6 @@ class LabPage(ctk.CTkFrame):
         out_dir = self.cfg["last_settings"].get("output_dir", os.getcwd()); ensure_dir(out_dir)
         import json, datetime
         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        path = os.path.join(out_dir, f"lab_all_{ts}.json")
+        path = os.path.join(out_dir, f"experimental_all_{ts}.json")
         with open(path, "w", encoding="utf-8") as f: json.dump(self.results, f, indent=2, ensure_ascii=False)
         self.log(f"[EXPORT] all -> {path}")


### PR DESCRIPTION
## Summary
- Rename LatencyLab branding to PawdioLab in app UI
- Retitle lab tests as "Experimental Tests" throughout the interface
- Adjust export filenames to use experimental_* prefixes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899864e910c83338d23b414e6ec086c