### PR TITLE
feat: support per-device sample rates

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,8 @@ def default_config():
         "per_sound_offsets_ms": {},
         "last_settings": {
             "sample_rate": 44100,
+            "input_sample_rate": 44100,
+            "output_sample_rate": 44100,
             "duration": 0.5,
             "repeats": 5,
             "input_device_index": None,
@@ -37,6 +39,11 @@ def load_config(path=CALIBRATION_JSON):
             pass
     cfg.setdefault("per_sound_offsets_ms", {})
     cfg.setdefault("ui", {}).setdefault("labs_enabled", True)
+    ls = cfg.setdefault("last_settings", {})
+    if "input_sample_rate" not in ls:
+        ls["input_sample_rate"] = ls.get("sample_rate", 44100)
+    if "output_sample_rate" not in ls:
+        ls["output_sample_rate"] = ls.get("sample_rate", 44100)
     return cfg
 
 def save_config(cfg, path=CALIBRATION_JSON):

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,8 @@ def default_config():
             "sample_rate": 44100,
             "input_sample_rate": 44100,
             "output_sample_rate": 44100,
+            "input_bit_depth": 16,
+            "output_bit_depth": 16,
             "duration": 0.5,
             "repeats": 5,
             "input_device_index": None,
@@ -44,6 +46,10 @@ def load_config(path=CALIBRATION_JSON):
         ls["input_sample_rate"] = ls.get("sample_rate", 44100)
     if "output_sample_rate" not in ls:
         ls["output_sample_rate"] = ls.get("sample_rate", 44100)
+    if "input_bit_depth" not in ls:
+        ls["input_bit_depth"] = 16
+    if "output_bit_depth" not in ls:
+        ls["output_bit_depth"] = 16
     return cfg
 
 def save_config(cfg, path=CALIBRATION_JSON):

--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -78,7 +78,14 @@ class AudioCore:
         if device_index is None:
             return [], []
 
+        info = self.audio.get_device_info_by_index(device_index)
+        channels_key = "maxInputChannels" if is_input else "maxOutputChannels"
+        channels = int(info.get(channels_key, 1)) or 1
+
+        default_rate = int(info.get("defaultSampleRate", 0))
         standard_rates = [8000, 11025, 16000, 22050, 32000, 44100, 48000, 88200, 96000, 176400, 192000]
+        if default_rate and default_rate not in standard_rates:
+            standard_rates.append(default_rate)
         formats = {8: pyaudio.paInt8, 16: pyaudio.paInt16, 24: pyaudio.paInt24, 32: pyaudio.paInt32}
         supported_rates: List[int] = []
         supported_bits: List[int] = []
@@ -86,10 +93,10 @@ class AudioCore:
             try:
                 if self.audio.is_format_supported(rate,
                                                  input_device=device_index if is_input else None,
-                                                 input_channels=1 if is_input else None,
+                                                 input_channels=channels if is_input else None,
                                                  input_format=pyaudio.paInt16 if is_input else None,
                                                  output_device=device_index if not is_input else None,
-                                                 output_channels=1 if not is_input else None,
+                                                 output_channels=channels if not is_input else None,
                                                  output_format=pyaudio.paInt16 if not is_input else None):
                     supported_rates.append(rate)
             except Exception:
@@ -98,14 +105,15 @@ class AudioCore:
             try:
                 if self.audio.is_format_supported(self.sample_rate,
                                                  input_device=device_index if is_input else None,
-                                                 input_channels=1 if is_input else None,
+                                                 input_channels=channels if is_input else None,
                                                  input_format=fmt if is_input else None,
                                                  output_device=device_index if not is_input else None,
-                                                 output_channels=1 if not is_input else None,
+                                                 output_channels=channels if not is_input else None,
                                                  output_format=fmt if not is_input else None):
                     supported_bits.append(bits)
             except Exception:
                 pass
+        supported_rates = sorted(set(supported_rates))
         return supported_rates, supported_bits
 
     def set_devices(self, output_index=None, input_index=None):
@@ -195,15 +203,34 @@ class AudioCore:
                 pass
 
     def _apply_windows_sample_rate(self, device_index: int, rate: int, is_input: bool):
-        """Attempt to update the Windows default format for a device.
-
-        This implementation is a stub; actual modification of the Windows
-        device format requires additional platform specific code and
-        dependencies which may not be available at runtime.
-        """
+        """Attempt to update the Windows default format for a device."""
         try:
-            import comtypes  # type: ignore  # noqa: F401
-            # Placeholder for real implementation using pycaw/IAudioClient.
+            from ctypes import byref, sizeof, c_byte, memmove, POINTER, cast
+            from comtypes.automation import PROPVARIANT
+            from pycaw.pycaw import AudioUtilities
+            from pycaw.constants import PKEY_AudioEngine_DeviceFormat
+            from pycaw.utils import AudioFormat
+
+            pa_name = self.audio.get_device_info_by_index(device_index).get("name")
+            devices = AudioUtilities.GetAllDevices()
+            device = next((d for d in devices if d.FriendlyName == pa_name), None)
+            if device is None:
+                return
+            store = device.OpenPropertyStore()
+            channels = 1 if is_input else 2
+            bits = 16
+            block_align = channels * bits // 8
+            avg_bytes = rate * block_align
+            fmt = AudioFormat(1, channels, rate, avg_bytes, block_align, bits, 0)
+
+            blob = (c_byte * sizeof(fmt))()
+            memmove(blob, byref(fmt), sizeof(fmt))
+            pv = PROPVARIANT()
+            pv.vt = 0x1011  # VT_BLOB
+            pv.blob.cbSize = sizeof(fmt)
+            pv.blob.pBlobData = cast(blob, POINTER(c_byte))
+            store.SetValue(PKEY_AudioEngine_DeviceFormat, pv)
+            store.Commit()
         except Exception:
             pass
 

--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -32,8 +32,19 @@ class AudioCore:
 
     def list_devices(self):
         devs = []
+        wasapi_index = None
+        if sys.platform.startswith("win"):
+            try:
+                wasapi_index = self.audio.get_host_api_info_by_type(pyaudio.paWASAPI)["index"]
+            except Exception:
+                pass
         for i in range(self.audio.get_device_count()):
             info = self.audio.get_device_info_by_index(i)
+            if wasapi_index is not None:
+                if info.get("hostApi") != wasapi_index:
+                    continue
+                if info.get("isLoopbackDevice", False):
+                    continue
             devs.append(info)
         return devs
 

--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -2,10 +2,27 @@
 import numpy as np
 from scipy import signal
 import pyaudio
+import sys
+from typing import List, Tuple
 
 class AudioCore:
-    def __init__(self, sample_rate=44100, chunk_size=1024, duration=0.5, output_device_index=None, input_device_index=None):
+    def __init__(self, sample_rate=44100, chunk_size=1024, duration=0.5,
+                 output_device_index=None, input_device_index=None,
+                 input_sample_rate=None):
+        """Initialize the audio core.
+
+        Parameters
+        ----------
+        sample_rate : int
+            Output sample rate. Historically this was the single sample rate
+            used by the application so we keep the attribute name for
+            backwards compatibility.
+        input_sample_rate : int or None
+            Optional input device sample rate. If ``None`` the output sample
+            rate is used.
+        """
         self.sample_rate = int(sample_rate)
+        self.input_sample_rate = int(input_sample_rate) if input_sample_rate is not None else int(sample_rate)
         self.chunk_size = int(chunk_size)
         self.duration = float(duration)
         self.audio = pyaudio.PyAudio()
@@ -19,6 +36,66 @@ class AudioCore:
             info = self.audio.get_device_info_by_index(i)
             devs.append(info)
         return devs
+
+    def get_default_output_index(self):
+        try:
+            return self.audio.get_default_output_device_info().get("index")
+        except Exception:
+            return None
+
+    def get_default_input_index(self):
+        try:
+            return self.audio.get_default_input_device_info().get("index")
+        except Exception:
+            return None
+
+    def get_device_capabilities(self, device_index: int, is_input: bool) -> Tuple[List[int], List[int]]:
+        """Return supported sample rates and bit depths for a device.
+
+        Parameters
+        ----------
+        device_index : int
+            The PortAudio index of the device to probe.
+        is_input : bool
+            ``True`` for input device, ``False`` for output device.
+
+        Returns
+        -------
+        (rates, bit_depths) : tuple(list[int], list[int])
+            Lists of supported sample rates and bit depths.
+        """
+        if device_index is None:
+            return [], []
+
+        standard_rates = [8000, 11025, 16000, 22050, 32000, 44100, 48000, 88200, 96000, 176400, 192000]
+        formats = {8: pyaudio.paInt8, 16: pyaudio.paInt16, 24: pyaudio.paInt24, 32: pyaudio.paInt32}
+        supported_rates: List[int] = []
+        supported_bits: List[int] = []
+        for rate in standard_rates:
+            try:
+                if self.audio.is_format_supported(rate,
+                                                 input_device=device_index if is_input else None,
+                                                 input_channels=1 if is_input else None,
+                                                 input_format=pyaudio.paInt16 if is_input else None,
+                                                 output_device=device_index if not is_input else None,
+                                                 output_channels=1 if not is_input else None,
+                                                 output_format=pyaudio.paInt16 if not is_input else None):
+                    supported_rates.append(rate)
+            except Exception:
+                pass
+        for bits, fmt in formats.items():
+            try:
+                if self.audio.is_format_supported(self.sample_rate,
+                                                 input_device=device_index if is_input else None,
+                                                 input_channels=1 if is_input else None,
+                                                 input_format=fmt if is_input else None,
+                                                 output_device=device_index if not is_input else None,
+                                                 output_channels=1 if not is_input else None,
+                                                 output_format=fmt if not is_input else None):
+                    supported_bits.append(bits)
+            except Exception:
+                pass
+        return supported_rates, supported_bits
 
     def set_devices(self, output_index=None, input_index=None):
         self.output_device_index = output_index
@@ -82,16 +159,42 @@ class AudioCore:
         out.write(audio_data); out.stop_stream(); out.close()
 
     def record_audio(self, duration):
-        inp = self.audio.open(format=pyaudio.paInt16, channels=1, rate=self.sample_rate, input=True,
+        inp = self.audio.open(format=pyaudio.paInt16, channels=1, rate=self.input_sample_rate, input=True,
                               frames_per_buffer=self.chunk_size, input_device_index=self.input_device_index)
         frames = []
-        num_chunks = int(self.sample_rate * duration / self.chunk_size)
+        num_chunks = int(self.input_sample_rate * duration / self.chunk_size)
         for _ in range(num_chunks):
             data = inp.read(self.chunk_size, exception_on_overflow=False)
             frames.append(data)
         inp.stop_stream(); inp.close()
         audio_data = np.frombuffer(b"".join(frames), dtype=np.int16).astype(np.float32)/32767.0
         return audio_data
+
+    def set_sample_rates(self, output_rate: int = None, input_rate: int = None):
+        if output_rate is not None:
+            self.sample_rate = int(output_rate)
+        if input_rate is not None:
+            self.input_sample_rate = int(input_rate)
+
+        if sys.platform.startswith("win"):
+            try:
+                self._apply_windows_sample_rate(self.output_device_index, self.sample_rate, False)
+                self._apply_windows_sample_rate(self.input_device_index, self.input_sample_rate, True)
+            except Exception:
+                pass
+
+    def _apply_windows_sample_rate(self, device_index: int, rate: int, is_input: bool):
+        """Attempt to update the Windows default format for a device.
+
+        This implementation is a stub; actual modification of the Windows
+        device format requires additional platform specific code and
+        dependencies which may not be available at runtime.
+        """
+        try:
+            import comtypes  # type: ignore  # noqa: F401
+            # Placeholder for real implementation using pycaw/IAudioClient.
+        except Exception:
+            pass
 
     @staticmethod
     def find_delay_ms(recorded_signal, reference_signal, sample_rate):

--- a/app/experimental_tests/delay.py
+++ b/app/experimental_tests/delay.py
@@ -34,8 +34,13 @@ class DelayRunner:
         time.sleep(0.08)
         core.play_mono(core.test_signal)
         t.join()
-        delay_ms, _ = AudioCore.find_delay_ms(rec_data["audio"], core.test_signal, core.sample_rate)
-        return delay_ms, rec_data["audio"], core.test_signal
+        ref = core.test_signal
+        if core.input_sample_rate != core.sample_rate and ref is not None:
+            # Resample reference to match recording rate
+            ref_len = int(len(ref) * core.input_sample_rate / core.sample_rate)
+            ref = signal.resample(ref, ref_len)
+        delay_ms, _ = AudioCore.find_delay_ms(rec_data["audio"], ref, core.input_sample_rate)
+        return delay_ms, rec_data["audio"], ref
 
     # Calibration
     def calibrate_preset(self, core, preset, repeats=5):
@@ -94,7 +99,7 @@ class DelayRunner:
             rec, ref = first_good
             ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             out = os.path.join(save_plot_dir, f"{preset['key']}_plot_{ts}.png")
-            self._save_plot(rec, ref, avg, core.sample_rate, out, f"{preset['name']} avg {avg:.1f} ms")
+            self._save_plot(rec, ref, avg, core.input_sample_rate, out, f"{preset['name']} avg {avg:.1f} ms")
             self.log(f"  saved plot -> {out}")
         return results
 

--- a/app/experimental_tests/sweep_fr.py
+++ b/app/experimental_tests/sweep_fr.py
@@ -12,18 +12,25 @@ def run(core, log, f0=20, f1=20000, duration=6.0, save_plot_dir=None):
     sig, t = core.generate_log_chirp(f0=f0, f1=f1, duration=duration, amp=0.5)
     rec = _play_and_record(core, sig, both=True, settle=0.05, rec_dur=duration+0.5)
 
-    delay_ms, _ = AudioCore.find_delay_ms(rec, sig, core.sample_rate)
+    if core.input_sample_rate != core.sample_rate:
+        sig_ref = signal.resample(sig, int(len(sig)*core.input_sample_rate/core.sample_rate))
+        t_ref = np.linspace(0, duration, len(sig_ref), endpoint=False)
+    else:
+        sig_ref = sig
+        t_ref = t
+
+    delay_ms, _ = AudioCore.find_delay_ms(rec, sig_ref, core.input_sample_rate)
     delay_s = 0.0 if delay_ms is None else delay_ms/1000.0
-    shift = int(round(delay_s * core.sample_rate))
-    rec_aligned = rec[shift: shift + len(sig)] if shift >= 0 else rec[:len(sig)]
-    if len(rec_aligned) < len(sig):
-        rec_aligned = np.pad(rec_aligned, (0, len(sig)-len(rec_aligned)))
+    shift = int(round(delay_s * core.input_sample_rate))
+    rec_aligned = rec[shift: shift + len(sig_ref)] if shift >= 0 else rec[:len(sig_ref)]
+    if len(rec_aligned) < len(sig_ref):
+        rec_aligned = np.pad(rec_aligned, (0, len(sig_ref)-len(rec_aligned)))
 
     env = np.abs(signal.hilbert(rec_aligned))
     env = env / (np.max(env)+1e-12)
 
     T = duration
-    freqs_inst = f0 * (f1/f0) ** (t / T)
+    freqs_inst = f0 * (f1/f0) ** (t_ref / T)
 
     grid = np.logspace(np.log10(max(20,f0)), np.log10(min(f1,20000)), 200)
     mag = np.zeros_like(grid)

--- a/app/experimental_tests/thd.py
+++ b/app/experimental_tests/thd.py
@@ -9,7 +9,7 @@ def run(core, log, tones=(100, 1000, 6000), tone_dur=1.0, amp=0.6):
     for f in tones:
         sig = core.generate_sine(freq=f, duration=tone_dur, amp=amp)
         rec = _play_and_record(core, sig, both=True, settle=0.05)
-        thd = _compute_thd(rec, f, sr=core.sample_rate)
+        thd = _compute_thd(rec, f, sr=core.input_sample_rate)
         items.append({"freq": f, "thd_percent": thd})
         log(f"  {f} Hz -> {thd:.3f}%")
     res = TestResult("thd", params={"tones": list(tones), "tone_dur": tone_dur}, metrics={"items": items})

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -31,10 +31,11 @@ class MainApp(ctk.CTk):
         self.main = ctk.CTkFrame(self, corner_radius=0); self.main.grid(row=0, column=1, sticky="nsew")
         self.main.grid_rowconfigure(0, weight=1); self.main.grid_columnconfigure(0, weight=1)
 
-        self.core = AudioCore(sample_rate=self.cfg["last_settings"]["sample_rate"],
+        self.core = AudioCore(sample_rate=self.cfg["last_settings"].get("output_sample_rate", self.cfg["last_settings"].get("sample_rate", 44100)),
                               chunk_size=1024, duration=self.cfg["last_settings"]["duration"],
                               output_device_index=self.cfg["last_settings"]["output_device_index"],
-                              input_device_index=self.cfg["last_settings"]["input_device_index"])
+                              input_device_index=self.cfg["last_settings"]["input_device_index"],
+                              input_sample_rate=self.cfg["last_settings"].get("input_sample_rate", self.cfg["last_settings"].get("sample_rate", 44100)))
 
         self.pages = {}
         self.pages["latency"] = LatencyPage(self.main, self.core, self.cfg, self._log)

--- a/app/ui/pages/devices_page.py
+++ b/app/ui/pages/devices_page.py
@@ -98,19 +98,13 @@ class DevicesPage(ctk.CTkFrame):
         self.on_toggle_experimental(bool(self.experimental_var.get()))
 
     def _update_sr_menus(self):
-        out_idx = self._out_idx.get(self.out_menu.get())
-        in_idx = self._in_idx.get(self.in_menu.get())
-        rates_out, _ = self.core.get_device_capabilities(out_idx, is_input=False)
-        rates_in, _ = self.core.get_device_capabilities(in_idx, is_input=True)
-        out_info = self.core.audio.get_device_info_by_index(out_idx) if out_idx is not None else {}
-        in_info = self.core.audio.get_device_info_by_index(in_idx) if in_idx is not None else {}
-        out_default = int(out_info.get("defaultSampleRate", 44100))
-        in_default = int(in_info.get("defaultSampleRate", 44100))
-        out_values = sorted({str(r) for r in rates_out} | {str(out_default)}) or [str(out_default)]
-        in_values = sorted({str(r) for r in rates_in} | {str(in_default)}) or [str(in_default)]
-        self.out_sr_menu.configure(values=out_values)
-        self.in_sr_menu.configure(values=in_values)
-        stored_out = str(self.cfg["last_settings"].get("output_sample_rate", out_default))
-        stored_in = str(self.cfg["last_settings"].get("input_sample_rate", in_default))
-        self.out_sr_menu.set(stored_out if stored_out in out_values else out_values[0])
-        self.in_sr_menu.set(stored_in if stored_in in in_values else in_values[0])
+        # Populate sample rate menus with a broad range of options so users can
+        # manually match the system's settings. We offer values from 44.1 kHz up
+        # to 192 kHz in 100 Hz increments.
+        all_rates = [str(r) for r in range(44100, 192001, 100)]
+        self.out_sr_menu.configure(values=all_rates)
+        self.in_sr_menu.configure(values=all_rates)
+        stored_out = str(self.cfg["last_settings"].get("output_sample_rate", 44100))
+        stored_in = str(self.cfg["last_settings"].get("input_sample_rate", 44100))
+        self.out_sr_menu.set(stored_out if stored_out in all_rates else all_rates[0])
+        self.in_sr_menu.set(stored_in if stored_in in all_rates else all_rates[0])

--- a/app/ui/pages/devices_page.py
+++ b/app/ui/pages/devices_page.py
@@ -102,11 +102,15 @@ class DevicesPage(ctk.CTkFrame):
         in_idx = self._in_idx.get(self.in_menu.get())
         rates_out, _ = self.core.get_device_capabilities(out_idx, is_input=False)
         rates_in, _ = self.core.get_device_capabilities(in_idx, is_input=True)
-        out_values = [str(r) for r in rates_out] or [str(self.out_sr_var.get())]
-        in_values = [str(r) for r in rates_in] or [str(self.in_sr_var.get())]
+        out_info = self.core.audio.get_device_info_by_index(out_idx) if out_idx is not None else {}
+        in_info = self.core.audio.get_device_info_by_index(in_idx) if in_idx is not None else {}
+        out_default = int(out_info.get("defaultSampleRate", 44100))
+        in_default = int(in_info.get("defaultSampleRate", 44100))
+        out_values = sorted({str(r) for r in rates_out} | {str(out_default)}) or [str(out_default)]
+        in_values = sorted({str(r) for r in rates_in} | {str(in_default)}) or [str(in_default)]
         self.out_sr_menu.configure(values=out_values)
         self.in_sr_menu.configure(values=in_values)
-        if self.out_sr_var.get() not in out_values:
-            self.out_sr_menu.set(out_values[0])
-        if self.in_sr_var.get() not in in_values:
-            self.in_sr_menu.set(in_values[0])
+        stored_out = str(self.cfg["last_settings"].get("output_sample_rate", out_default))
+        stored_in = str(self.cfg["last_settings"].get("input_sample_rate", in_default))
+        self.out_sr_menu.set(stored_out if stored_out in out_values else out_values[0])
+        self.in_sr_menu.set(stored_in if stored_in in in_values else in_values[0])

--- a/app/ui/pages/devices_page.py
+++ b/app/ui/pages/devices_page.py
@@ -24,6 +24,18 @@ class DevicesPage(ctk.CTkFrame):
         self.dur_var = ctk.DoubleVar(value=self.cfg["last_settings"]["duration"])
         ctk.CTkEntry(card, textvariable=self.dur_var, width=120).grid(row=0, column=5, padx=8, pady=8, sticky="w")
         ctk.CTkButton(card, text="Apply", command=self._apply).grid(row=0, column=6, padx=8, pady=8, sticky="e")
+        self.out_bits_label = ctk.CTkLabel(card, text="Output Bit Depth")
+        self.out_bits_label.grid(row=1, column=0, padx=8, pady=8, sticky="w")
+        self.out_bits_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("output_bit_depth", "")))
+        self.out_bits_menu = ctk.CTkOptionMenu(card, values=[], variable=self.out_bits_var, width=120)
+        self.out_bits_menu.grid(row=1, column=1, padx=8, pady=8, sticky="w")
+        self.in_bits_label = ctk.CTkLabel(card, text="Input Bit Depth")
+        self.in_bits_label.grid(row=1, column=2, padx=8, pady=8, sticky="w")
+        self.in_bits_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("input_bit_depth", "")))
+        self.in_bits_menu = ctk.CTkOptionMenu(card, values=[], variable=self.in_bits_var, width=120)
+        self.in_bits_menu.grid(row=1, column=3, padx=8, pady=8, sticky="w")
+        self.out_bits_label.grid_remove(); self.out_bits_menu.grid_remove()
+        self.in_bits_label.grid_remove(); self.in_bits_menu.grid_remove()
 
         dev = ctk.CTkFrame(self); dev.grid(row=2, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
         dev.grid_columnconfigure(1, weight=1)
@@ -52,6 +64,10 @@ class DevicesPage(ctk.CTkFrame):
             self.cfg["last_settings"]["output_sample_rate"] = self.core.sample_rate
             self.cfg["last_settings"]["input_sample_rate"] = self.core.input_sample_rate
             self.cfg["last_settings"]["sample_rate"] = self.core.sample_rate
+            if self.out_bits_var.get():
+                self.cfg["last_settings"]["output_bit_depth"] = int(self.out_bits_var.get())
+            if self.in_bits_var.get():
+                self.cfg["last_settings"]["input_bit_depth"] = int(self.in_bits_var.get())
             self.cfg["last_settings"]["duration"] = self.core.duration
             self.cfg["ui"]["appearance_mode"] = self.appearance.get()
             self.cfg["ui"]["color_theme"] = self.color.get()
@@ -91,6 +107,10 @@ class DevicesPage(ctk.CTkFrame):
         self.cfg["last_settings"]["input_device_index"] = in_idx
         self.cfg["last_settings"]["output_sample_rate"] = self.core.sample_rate
         self.cfg["last_settings"]["input_sample_rate"] = self.core.input_sample_rate
+        if self.out_bits_var.get():
+            self.cfg["last_settings"]["output_bit_depth"] = int(self.out_bits_var.get())
+        if self.in_bits_var.get():
+            self.cfg["last_settings"]["input_bit_depth"] = int(self.in_bits_var.get())
         save_config(self.cfg); self.log(f"[SET] devices out={out_idx}, in={in_idx}, sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}")
 
     def _toggle_experimental(self):
@@ -98,13 +118,51 @@ class DevicesPage(ctk.CTkFrame):
         self.on_toggle_experimental(bool(self.experimental_var.get()))
 
     def _update_sr_menus(self):
-        # Populate sample rate menus with a broad range of options so users can
-        # manually match the system's settings. We offer values from 44.1 kHz up
-        # to 192 kHz in 100 Hz increments.
-        all_rates = [str(r) for r in range(44100, 192001, 100)]
-        self.out_sr_menu.configure(values=all_rates)
-        self.in_sr_menu.configure(values=all_rates)
+        out_idx = self._out_idx.get(self.out_menu.get())
+        in_idx = self._in_idx.get(self.in_menu.get())
+
+        out_rates, out_bits = self.core.get_device_capabilities(out_idx, False)
+        in_rates, in_bits = self.core.get_device_capabilities(in_idx, True)
+
+        out_rate_vals = [str(r) for r in out_rates]
+        in_rate_vals = [str(r) for r in in_rates]
+        self.out_sr_menu.configure(values=out_rate_vals)
+        self.in_sr_menu.configure(values=in_rate_vals)
+
         stored_out = str(self.cfg["last_settings"].get("output_sample_rate", 44100))
         stored_in = str(self.cfg["last_settings"].get("input_sample_rate", 44100))
-        self.out_sr_menu.set(stored_out if stored_out in all_rates else all_rates[0])
-        self.in_sr_menu.set(stored_in if stored_in in all_rates else all_rates[0])
+        def _pick_rate(stored, vals, default_info_idx):
+            if stored in vals:
+                return stored
+            if default_info_idx is not None:
+                info = self.core.audio.get_device_info_by_index(default_info_idx)
+                default_rate = str(int(info.get("defaultSampleRate", 0)))
+                if default_rate in vals:
+                    return default_rate
+            return vals[0] if vals else stored
+
+        self.out_sr_menu.set(_pick_rate(stored_out, out_rate_vals, out_idx))
+        self.in_sr_menu.set(_pick_rate(stored_in, in_rate_vals, in_idx))
+
+        out_bit_vals = [str(b) for b in out_bits]
+        in_bit_vals = [str(b) for b in in_bits]
+        self.out_bits_menu.configure(values=out_bit_vals)
+        self.in_bits_menu.configure(values=in_bit_vals)
+
+        if len(out_bit_vals) > 1:
+            self.out_bits_label.grid(); self.out_bits_menu.grid()
+            stored = str(self.cfg["last_settings"].get("output_bit_depth", out_bit_vals[0]))
+            self.out_bits_menu.set(stored if stored in out_bit_vals else out_bit_vals[0])
+        else:
+            self.out_bits_label.grid_remove(); self.out_bits_menu.grid_remove()
+            if out_bit_vals:
+                self.out_bits_var.set(out_bit_vals[0])
+
+        if len(in_bit_vals) > 1:
+            self.in_bits_label.grid(); self.in_bits_menu.grid()
+            stored = str(self.cfg["last_settings"].get("input_bit_depth", in_bit_vals[0]))
+            self.in_bits_menu.set(stored if stored in in_bit_vals else in_bit_vals[0])
+        else:
+            self.in_bits_label.grid_remove(); self.in_bits_menu.grid_remove()
+            if in_bit_vals:
+                self.in_bits_var.set(in_bit_vals[0])

--- a/app/ui/pages/devices_page.py
+++ b/app/ui/pages/devices_page.py
@@ -11,21 +11,26 @@ class DevicesPage(ctk.CTkFrame):
         ctk.CTkLabel(self, text="Devices / Settings", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, columnspan=2, padx=18, pady=(18,4), sticky="w")
 
         card = ctk.CTkFrame(self); card.grid(row=1, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        for i in range(6): card.grid_columnconfigure(i, weight=1)
-        ctk.CTkLabel(card, text="Sample Rate").grid(row=0, column=0, padx=8, pady=8, sticky="w")
-        self.sr_var = ctk.IntVar(value=self.cfg["last_settings"]["sample_rate"])
-        ctk.CTkEntry(card, textvariable=self.sr_var, width=120).grid(row=0, column=1, padx=8, pady=8, sticky="w")
-        ctk.CTkLabel(card, text="Signal Duration (s)").grid(row=0, column=2, padx=8, pady=8, sticky="w")
+        for i in range(7): card.grid_columnconfigure(i, weight=1)
+        ctk.CTkLabel(card, text="Output Sample Rate").grid(row=0, column=0, padx=8, pady=8, sticky="w")
+        self.out_sr_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("output_sample_rate", 44100)))
+        self.out_sr_menu = ctk.CTkOptionMenu(card, values=[], variable=self.out_sr_var, width=120)
+        self.out_sr_menu.grid(row=0, column=1, padx=8, pady=8, sticky="w")
+        ctk.CTkLabel(card, text="Input Sample Rate").grid(row=0, column=2, padx=8, pady=8, sticky="w")
+        self.in_sr_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("input_sample_rate", 44100)))
+        self.in_sr_menu = ctk.CTkOptionMenu(card, values=[], variable=self.in_sr_var, width=120)
+        self.in_sr_menu.grid(row=0, column=3, padx=8, pady=8, sticky="w")
+        ctk.CTkLabel(card, text="Signal Duration (s)").grid(row=0, column=4, padx=8, pady=8, sticky="w")
         self.dur_var = ctk.DoubleVar(value=self.cfg["last_settings"]["duration"])
-        ctk.CTkEntry(card, textvariable=self.dur_var, width=120).grid(row=0, column=3, padx=8, pady=8, sticky="w")
-        ctk.CTkButton(card, text="Apply", command=self._apply).grid(row=0, column=5, padx=8, pady=8, sticky="e")
+        ctk.CTkEntry(card, textvariable=self.dur_var, width=120).grid(row=0, column=5, padx=8, pady=8, sticky="w")
+        ctk.CTkButton(card, text="Apply", command=self._apply).grid(row=0, column=6, padx=8, pady=8, sticky="e")
 
         dev = ctk.CTkFrame(self); dev.grid(row=2, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
         dev.grid_columnconfigure(1, weight=1)
         ctk.CTkLabel(dev, text="Output Device").grid(row=0, column=0, padx=8, pady=(8,4), sticky="w")
-        self.out_menu = ctk.CTkOptionMenu(dev, values=["<refresh>"]); self.out_menu.grid(row=0, column=1, padx=8, pady=(8,4), sticky="ew")
+        self.out_menu = ctk.CTkOptionMenu(dev, values=["<refresh>"], command=lambda _: self._update_sr_menus()); self.out_menu.grid(row=0, column=1, padx=8, pady=(8,4), sticky="ew")
         ctk.CTkLabel(dev, text="Input Device").grid(row=1, column=0, padx=8, pady=(4,8), sticky="w")
-        self.in_menu = ctk.CTkOptionMenu(dev, values=["<refresh>"]); self.in_menu.grid(row=1, column=1, padx=8, pady=(4,8), sticky="ew")
+        self.in_menu = ctk.CTkOptionMenu(dev, values=["<refresh>"], command=lambda _: self._update_sr_menus()); self.in_menu.grid(row=1, column=1, padx=8, pady=(4,8), sticky="ew")
         ctk.CTkButton(dev, text="Refresh Devices", command=self._refresh_devices).grid(row=0, column=2, rowspan=2, padx=8)
 
         ap = ctk.CTkFrame(self); ap.grid(row=3, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
@@ -42,14 +47,16 @@ class DevicesPage(ctk.CTkFrame):
 
     def _apply(self):
         try:
-            self.core.sample_rate = int(self.sr_var.get())
+            self.core.set_sample_rates(output_rate=int(self.out_sr_menu.get()), input_rate=int(self.in_sr_menu.get()))
             self.core.duration = float(self.dur_var.get())
+            self.cfg["last_settings"]["output_sample_rate"] = self.core.sample_rate
+            self.cfg["last_settings"]["input_sample_rate"] = self.core.input_sample_rate
             self.cfg["last_settings"]["sample_rate"] = self.core.sample_rate
             self.cfg["last_settings"]["duration"] = self.core.duration
             self.cfg["ui"]["appearance_mode"] = self.appearance.get()
             self.cfg["ui"]["color_theme"] = self.color.get()
             save_config(self.cfg)
-            self.log(f"[SET] sr={self.core.sample_rate}, dur={self.core.duration}s, theme={self.appearance.get()}/{self.color.get()}")
+            self.log(f"[SET] sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}, dur={self.core.duration}s, theme={self.appearance.get()}/{self.color.get()}")
         except Exception as e:
             self.log(f"[ERROR] settings: {e}")
 
@@ -65,19 +72,41 @@ class DevicesPage(ctk.CTkFrame):
         self.out_menu.configure(values=out_values or ["<no outputs>"]); self.in_menu.configure(values=in_values or ["<no inputs>"])
         out_stored = self.cfg["last_settings"].get("output_device_index")
         in_stored = self.cfg["last_settings"].get("input_device_index")
+        out_default = self.core.get_default_output_index()
+        in_default = self.core.get_default_input_index()
         if out_values:
-            target = next((lbl for lbl,idx in self._out_idx.items() if idx==out_stored), out_values[0]); self.out_menu.set(target)
+            target_idx = out_stored if out_stored is not None else out_default
+            target = next((lbl for lbl,idx in self._out_idx.items() if idx==target_idx), out_values[0]); self.out_menu.set(target)
         if in_values:
-            target = next((lbl for lbl,idx in self._in_idx.items() if idx==in_stored), in_values[0]); self.in_menu.set(target)
+            target_idx = in_stored if in_stored is not None else in_default
+            target = next((lbl for lbl,idx in self._in_idx.items() if idx==target_idx), in_values[0]); self.in_menu.set(target)
+        self._update_sr_menus()
 
     def use_selected_devices(self):
         out_idx = self._out_idx.get(self.out_menu.get()); in_idx = self._in_idx.get(self.in_menu.get())
         if out_idx is None or in_idx is None: return
         self.core.set_devices(output_index=out_idx, input_index=in_idx)
+        self.core.set_sample_rates(output_rate=int(self.out_sr_menu.get()), input_rate=int(self.in_sr_menu.get()))
         self.cfg["last_settings"]["output_device_index"] = out_idx
         self.cfg["last_settings"]["input_device_index"] = in_idx
-        save_config(self.cfg); self.log(f"[SET] devices out={out_idx}, in={in_idx}")
+        self.cfg["last_settings"]["output_sample_rate"] = self.core.sample_rate
+        self.cfg["last_settings"]["input_sample_rate"] = self.core.input_sample_rate
+        save_config(self.cfg); self.log(f"[SET] devices out={out_idx}, in={in_idx}, sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}")
 
     def _toggle_experimental(self):
         self.cfg["ui"]["labs_enabled"] = bool(self.experimental_var.get()); save_config(self.cfg)
         self.on_toggle_experimental(bool(self.experimental_var.get()))
+
+    def _update_sr_menus(self):
+        out_idx = self._out_idx.get(self.out_menu.get())
+        in_idx = self._in_idx.get(self.in_menu.get())
+        rates_out, _ = self.core.get_device_capabilities(out_idx, is_input=False)
+        rates_in, _ = self.core.get_device_capabilities(in_idx, is_input=True)
+        out_values = [str(r) for r in rates_out] or [str(self.out_sr_var.get())]
+        in_values = [str(r) for r in rates_in] or [str(self.in_sr_var.get())]
+        self.out_sr_menu.configure(values=out_values)
+        self.in_sr_menu.configure(values=in_values)
+        if self.out_sr_var.get() not in out_values:
+            self.out_sr_menu.set(out_values[0])
+        if self.in_sr_var.get() not in in_values:
+            self.in_sr_menu.set(in_values[0])

--- a/app/ui/pages/latency_page.py
+++ b/app/ui/pages/latency_page.py
@@ -165,7 +165,8 @@ class LatencyPage(ctk.CTkScrollableFrame):
     def _build_text_report(self):
         all_results = getattr(self, "last_all_results", {})
         repeats = getattr(self, "last_repeats", 0)
-        sr = self.core.sample_rate
+        sr_out = self.core.sample_rate
+        sr_in = self.core.input_sample_rate
         dur = self.core.duration
         global_off = float(self.cfg.get("global_system_offset_ms", 0.0))
         now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -181,7 +182,8 @@ class LatencyPage(ctk.CTkScrollableFrame):
             "="*60,
             f"Test Date: {now}",
             f"Overall Tests Per Sound Type: {repeats}",
-            f"Sample Rate: {sr} Hz",
+            f"Output Sample Rate: {sr_out} Hz",
+            f"Input Sample Rate: {sr_in} Hz",
             f"Default Test Signal Buffer Duration: {dur} seconds (Sine waves use this primarily)",
             f"Calibration Offset Applied: {global_off:.4f} ms",
             "",


### PR DESCRIPTION
## Summary
- detect supported sample rates/bit depths for input and output devices
- allow selecting separate sample rates for input and output devices
- default device selection honors OS defaults and stubs Windows sample-rate update

## Testing
- `python -m py_compile app/config.py app/core/audio.py app/experimental_tests/delay.py app/experimental_tests/sweep_fr.py app/experimental_tests/thd.py app/ui/app.py app/ui/pages/devices_page.py app/ui/pages/latency_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68999aff09b48333bd021a77f16775bc