### PR TITLE
Enable stereo audio handling in tests

### DIFF
--- a/app/experimental_tests/balance.py
+++ b/app/experimental_tests/balance.py
@@ -7,14 +7,14 @@ def run(core, log, freq=1000.0, tone_dur=1.0, settle=0.2):
     log("[BALANCE] Place mic on LEFT earcup, then click OK")
     messagebox.showinfo("Balance", "Place mic on LEFT earcup, then click OK")
     sig = core.generate_sine(freq=freq, duration=tone_dur)
-    recL = _play_and_record(core, sig, both=True, settle=settle)
+    recL = _play_and_record(core, sig, settle=settle)
 
     log("[BALANCE] Move mic to RIGHT earcup, then click OK")
     messagebox.showinfo("Balance", "Move mic to RIGHT earcup, then click OK")
     core.generate_sine(freq=freq, duration=tone_dur)
-    recR = _play_and_record(core, core.test_signal, both=True, settle=settle)
-
-    levelL = dbfs(recL); levelR = dbfs(recR)
+    recR = _play_and_record(core, core.test_signal, settle=settle)
+    levelL = dbfs(recL[:,0] if recL is not None and recL.ndim==2 else recL)
+    levelR = dbfs(recR[:,0] if recR is not None and recR.ndim==2 else recR)
     diff = levelL - levelR
     res = TestResult("balance",
         params={"freq": freq, "duration": tone_dur},
@@ -27,9 +27,13 @@ def _play_and_record(core, mono_signal, both=False, settle=0.05, rec_dur=None):
     import threading, time
     if rec_dur is None: rec_dur = float(core.duration) + 0.3
     rec = {"audio": None}
-    def worker(): rec["audio"] = core.record_audio(rec_dur)
+    def worker():
+        ch = 2 if both else 1
+        rec["audio"] = core.record_audio(rec_dur, channels=ch)
     t = threading.Thread(target=worker, daemon=True); t.start()
     time.sleep(0.05 + settle)
-    if both: core.play_stereo(mono_signal, mono_signal)
-    else: core.play_mono(mono_signal)
+    if both:
+        core.play_stereo(mono_signal, mono_signal)
+    else:
+        core.play_mono(mono_signal)
     t.join(); return rec["audio"]

--- a/app/experimental_tests/crosstalk.py
+++ b/app/experimental_tests/crosstalk.py
@@ -25,8 +25,8 @@ def run(core, log, freq=1000.0, tone_dur=1.0, settle=0.2, direction="LtoR"):
         messagebox.showinfo("Crosstalk", "Move mic to LEFT earcup (LEAK), then click OK")
         core.generate_sine(freq=freq, duration=tone_dur)
         rec_leak = _play_and_record(core, core.test_signal, right_only=True, settle=settle)
-
-    p = rms(rec_primary); l = rms(rec_leak)
+    p = rms(rec_primary)
+    l = rms(rec_leak)
     crosstalk_db = 20*np.log10(max(l,1e-12)/max(p,1e-12))
     res = TestResult("crosstalk",
         params={"freq": freq, "duration": tone_dur, "direction": direction},
@@ -35,11 +35,12 @@ def run(core, log, freq=1000.0, tone_dur=1.0, settle=0.2, direction="LtoR"):
     log(f"[CROSSTALK {direction}] {crosstalk_db:.2f} dB")
     return res
 
-def _play_and_record(core, mono_signal, left_only=False, right_only=False, both=False, settle=0.05, rec_dur=None):
+def _play_and_record(core, mono_signal, left_only=False, right_only=False, settle=0.05, rec_dur=None):
     import threading, time, numpy as np
     if rec_dur is None: rec_dur = float(core.duration) + 0.3
     rec = {"audio": None}
-    def worker(): rec["audio"] = core.record_audio(rec_dur)
+    def worker():
+        rec["audio"] = core.record_audio(rec_dur, channels=1)
     t = threading.Thread(target=worker, daemon=True); t.start()
     time.sleep(0.05 + settle)
     if left_only:

--- a/app/experimental_tests/isolation.py
+++ b/app/experimental_tests/isolation.py
@@ -1,7 +1,7 @@
-
 from tkinter import messagebox
 from ..core.utils import dbfs
 from ..tests.base import TestResult
+
 
 def run(core, log, noise_dur=2.0, amp=0.4):
     log("[ISOLATION] Inside: mic near earcup seal. OK to measure.")
@@ -9,26 +9,52 @@ def run(core, log, noise_dur=2.0, amp=0.4):
     sig = core.generate_pink_noise(duration=noise_dur, amp=amp)
     rec_in = _play_and_record(core, sig, both=True, settle=0.05)
 
-    log("[ISOLATION] Outside: mic ~5–10 cm outside the cup. OK to measure.")
-    messagebox.showinfo("Isolation", "Move mic 5–10 cm outside the cup. Click OK.")
+    log("[ISOLATION] Outside: mic ~5-10 cm outside the cup. OK to measure.")
+    messagebox.showinfo("Isolation", "Move mic 5-10 cm outside the cup. Click OK.")
     core.generate_pink_noise(duration=noise_dur, amp=amp)
     rec_out = _play_and_record(core, core.test_signal, both=True, settle=0.05)
 
-    in_db = dbfs(rec_in); out_db = dbfs(rec_out); delta = in_db - out_db
-    res = TestResult("isolation_inside_out",
+    inL = dbfs(rec_in[:, 0]) if rec_in is not None and rec_in.ndim == 2 else dbfs(rec_in)
+    inR = dbfs(rec_in[:, 1]) if rec_in is not None and rec_in.ndim == 2 else inL
+    outL = dbfs(rec_out[:, 0]) if rec_out is not None and rec_out.ndim == 2 else dbfs(rec_out)
+    outR = dbfs(rec_out[:, 1]) if rec_out is not None and rec_out.ndim == 2 else outL
+    deltaL = inL - outL
+    deltaR = inR - outR
+
+    res = TestResult(
+        "isolation_inside_out",
         params={"noise_dur": noise_dur},
-        metrics={"inside_dBFS": in_db, "outside_dBFS": out_db, "delta_dB": delta}
+        metrics={
+            "left_inside_dBFS": inL,
+            "left_outside_dBFS": outL,
+            "left_delta_dB": deltaL,
+            "right_inside_dBFS": inR,
+            "right_outside_dBFS": outR,
+            "right_delta_dB": deltaR,
+        },
     )
-    log(f"[ISOLATION] Inside {in_db:.2f} dBFS, Outside {out_db:.2f} dBFS, Δ {delta:.2f} dB")
+    log(f"[ISOLATION] L Δ {deltaL:.2f} dB | R Δ {deltaR:.2f} dB")
     return res
+
 
 def _play_and_record(core, mono_signal, both=False, settle=0.05, rec_dur=None):
     import threading, time
-    if rec_dur is None: rec_dur = float(core.duration) + 0.3
+
+    if rec_dur is None:
+        rec_dur = float(core.duration) + 0.3
     rec = {"audio": None}
-    def worker(): rec["audio"] = core.record_audio(rec_dur)
-    t = threading.Thread(target=worker, daemon=True); t.start()
+
+    def worker():
+        ch = 2 if both else 1
+        rec["audio"] = core.record_audio(rec_dur, channels=ch)
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
     time.sleep(0.05 + settle)
-    if both: core.play_stereo(mono_signal, mono_signal)
-    else: core.play_mono(mono_signal)
-    t.join(); return rec["audio"]
+    if both:
+        core.play_stereo(mono_signal, mono_signal)
+    else:
+        core.play_mono(mono_signal)
+    t.join()
+    return rec["audio"]
+

--- a/app/experimental_tests/thd.py
+++ b/app/experimental_tests/thd.py
@@ -8,8 +8,9 @@ def run(core, log, tones=(100, 1000, 6000), tone_dur=1.0, amp=0.6):
     items = []
     for f in tones:
         sig = core.generate_sine(freq=f, duration=tone_dur, amp=amp)
-        rec = _play_and_record(core, sig, both=True, settle=0.05)
-        thd = _compute_thd(rec, f, sr=core.input_sample_rate)
+        rec = _play_and_record(core, sig, settle=0.05)
+        rec_mono = rec
+        thd = _compute_thd(rec_mono, f, sr=core.input_sample_rate)
         items.append({"freq": f, "thd_percent": thd})
         log(f"  {f} Hz -> {thd:.3f}%")
     res = TestResult("thd", params={"tones": list(tones), "tone_dur": tone_dur}, metrics={"items": items})
@@ -19,11 +20,15 @@ def _play_and_record(core, mono_signal, both=False, settle=0.05, rec_dur=None):
     import threading, time
     if rec_dur is None: rec_dur = float(core.duration) + 0.3
     rec = {"audio": None}
-    def worker(): rec["audio"] = core.record_audio(rec_dur)
+    def worker():
+        ch = 2 if both else 1
+        rec["audio"] = core.record_audio(rec_dur, channels=ch)
     t = threading.Thread(target=worker, daemon=True); t.start()
     time.sleep(0.05 + settle)
-    if both: core.play_stereo(mono_signal, mono_signal)
-    else: core.play_mono(mono_signal)
+    if both:
+        core.play_stereo(mono_signal, mono_signal)
+    else:
+        core.play_mono(mono_signal)
     t.join(); return rec["audio"]
 
 def _compute_thd(x, f0, sr, n_harm=10):

--- a/app/tests/latency.py
+++ b/app/tests/latency.py
@@ -17,9 +17,10 @@ SOUND_PRESETS = [
 ]
 
 class DelayRunner:
-    def __init__(self, cfg, log_fn):
+    def __init__(self, cfg, log_fn, stereo=False):
         self.cfg = cfg
         self.log = log_fn
+        self.stereo = stereo
 
     def _gen(self, core, preset):
         if preset["type"]=="sine":
@@ -29,16 +30,25 @@ class DelayRunner:
     def _record_and_play(self, core: AudioCore, preset, record_margin_s=1.0):
         rec_dur = float(core.duration) + float(record_margin_s)
         rec_data = {"audio": None}
-        def record_worker(): rec_data["audio"] = core.record_audio(rec_dur)
+        channels = 2 if self.stereo else 1
+        def record_worker():
+            rec_data["audio"] = core.record_audio(rec_dur, channels=channels)
         t = threading.Thread(target=record_worker, daemon=True); t.start()
         time.sleep(0.08)
-        core.play_mono(core.test_signal)
+        if self.stereo:
+            core.play_stereo(core.test_signal, core.test_signal)
+        else:
+            core.play_mono(core.test_signal)
         t.join()
         ref = core.test_signal
         if core.input_sample_rate != core.sample_rate and ref is not None:
             # Resample reference to match recording rate
             ref_len = int(len(ref) * core.input_sample_rate / core.sample_rate)
             ref = signal.resample(ref, ref_len)
+        if self.stereo and rec_data["audio"] is not None and rec_data["audio"].ndim == 2:
+            delay_l, _ = AudioCore.find_delay_ms(rec_data["audio"][:,0], ref, core.input_sample_rate)
+            delay_r, _ = AudioCore.find_delay_ms(rec_data["audio"][:,1], ref, core.input_sample_rate)
+            return (delay_l, delay_r), rec_data["audio"], ref
         delay_ms, _ = AudioCore.find_delay_ms(rec_data["audio"], ref, core.input_sample_rate)
         return delay_ms, rec_data["audio"], ref
 
@@ -49,6 +59,8 @@ class DelayRunner:
         for i in range(repeats):
             self._gen(core, preset)
             d, _, _ = self._record_and_play(core, preset)
+            if isinstance(d, tuple):
+                d = safe_mean([x for x in d if x is not None])
             if d is None: self.log(f"  ✗ {i+1}/{repeats}")
             else: self.log(f"  ✓ {i+1}/{repeats}: {d:.2f} ms")
             delays.append(d); time.sleep(0.15)
@@ -64,7 +76,10 @@ class DelayRunner:
         self.log(f"[CAL] GLOBAL via Impulse x{repeats}")
         delays=[]
         for i in range(repeats):
-            self._gen(core, pseudo); d,_,_ = self._record_and_play(core, pseudo)
+            self._gen(core, pseudo)
+            d, _, _ = self._record_and_play(core, pseudo)
+            if isinstance(d, tuple):
+                d = safe_mean([x for x in d if x is not None])
             if d is None: self.log(f"  ✗ {i+1}/{repeats}")
             else: self.log(f"  ✓ {i+1}/{repeats}: {d:.2f} ms")
             delays.append(d); time.sleep(0.15)
@@ -80,28 +95,47 @@ class DelayRunner:
         global_off = float(self.cfg.get("global_system_offset_ms", 0.0))
         calib = per_sound + global_off
         self.log(f"[TEST] {preset['name']} x{repeats}  (calib={calib:.2f} ms)")
-        results = []
+        results_l, results_r, results_avg, diffs = [], [], [], []
         first_good = None
         for i in range(repeats):
             self._gen(core, preset)
             d_raw, rec, ref = self._record_and_play(core, preset)
-            if d_raw is None:
-                self.log(f"  ✗ {i+1}/{repeats}"); results.append(None)
+            if isinstance(d_raw, tuple):
+                d_l, d_r = d_raw
             else:
-                d_cal = d_raw - calib; self.log(f"  ✓ {i+1}/{repeats}: {d_cal:.2f} ms")
-                results.append(d_cal)
+                d_l = d_r = d_raw
+            if d_l is None or d_r is None:
+                self.log(f"  ✗ {i+1}/{repeats}")
+            else:
+                d_l_cal = d_l - calib
+                d_r_cal = d_r - calib
+                avg = safe_mean([d_l_cal, d_r_cal])
+                diff = d_l_cal - d_r_cal
+                self.log(f"  ✓ {i+1}/{repeats}: L {d_l_cal:.2f} ms | R {d_r_cal:.2f} ms | Δ {diff:.2f} ms")
+                results_l.append(d_l_cal)
+                results_r.append(d_r_cal)
+                results_avg.append(avg)
+                diffs.append(diff)
                 if first_good is None and rec is not None and ref is not None:
                     first_good = (rec, ref)
             time.sleep(0.12)
-        avg, std = safe_mean(results), safe_std(results)
-        if avg is not None: self.log(f"  -> avg {avg:.2f} ± {std:.2f} ms")
-        if save_plot_dir and first_good and avg is not None:
+        avg_l, std_l = safe_mean(results_l), safe_std(results_l)
+        avg_r, std_r = safe_mean(results_r), safe_std(results_r)
+        avg_diff, std_diff = safe_mean(diffs), safe_std(diffs)
+        if avg_l is not None and avg_r is not None:
+            self.log(f"  -> L {avg_l:.2f} ± {std_l:.2f} ms | R {avg_r:.2f} ± {std_r:.2f} ms | Δ {avg_diff:.2f} ± {std_diff:.2f} ms")
+        if save_plot_dir and first_good and results_l and results_r:
             rec, ref = first_good
             ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-            out = os.path.join(save_plot_dir, f"{preset['key']}_plot_{ts}.png")
-            self._save_plot(rec, ref, avg, core.input_sample_rate, out, f"{preset['name']} avg {avg:.1f} ms")
-            self.log(f"  saved plot -> {out}")
-        return results
+            out_l = os.path.join(save_plot_dir, f"{preset['key']}_left_plot_{ts}.png")
+            out_r = os.path.join(save_plot_dir, f"{preset['key']}_right_plot_{ts}.png")
+            out_avg = os.path.join(save_plot_dir, f"{preset['key']}_avg_plot_{ts}.png")
+            self._save_plot(rec[:,0], ref, avg_l, core.input_sample_rate, out_l, f"{preset['name']} L avg {avg_l:.1f} ms")
+            self._save_plot(rec[:,1], ref, avg_r, core.input_sample_rate, out_r, f"{preset['name']} R avg {avg_r:.1f} ms")
+            avg_all = safe_mean([avg_l, avg_r])
+            self._save_plot(rec.mean(axis=1), ref, avg_all, core.input_sample_rate, out_avg, f"{preset['name']} avg {avg_all:.1f} ms")
+            self.log(f"  saved plots -> {out_l}, {out_r}, {out_avg}")
+        return {"left_ms": results_l, "right_ms": results_r, "avg_ms": results_avg, "diff_ms": diffs}
 
     @staticmethod
     def _save_plot(recorded_audio, test_signal, avg_delay_ms, sample_rate, filepath, title):
@@ -120,3 +154,15 @@ class DelayRunner:
         plt.plot(corr_time, correlation); plt.axvline(x=avg_delay_ms, linestyle="--", label=f"Avg: {avg_delay_ms:.1f} ms"); plt.legend()
         plt.xlabel("Delay (ms)"); plt.ylabel("corr")
         plt.tight_layout(); plt.savefig(filepath); plt.close()
+
+    @staticmethod
+    def save_bar(data, filepath):
+        labels = list(data.keys())
+        avgs = [np.mean(v) if v else 0.0 for v in data.values()]
+        plt.figure(figsize=(10,5))
+        plt.bar(labels, avgs)
+        plt.ylabel("Delay (ms)")
+        plt.tight_layout()
+        plt.savefig(filepath)
+        plt.close()
+        return True

--- a/app/ui/pages/latency_page.py
+++ b/app/ui/pages/latency_page.py
@@ -8,7 +8,7 @@ class LatencyPage(ctk.CTkScrollableFrame):
     def __init__(self, master, core, cfg, log_fn):
         super().__init__(master, corner_radius=0)
         self.core = core; self.cfg = cfg; self.log = log_fn
-        self.runner = DelayRunner(self.cfg, self.log)
+        self.runner = DelayRunner(self.cfg, self.log, stereo=True)
 
         self.grid_columnconfigure(1, weight=1)
 
@@ -136,10 +136,21 @@ class LatencyPage(ctk.CTkScrollableFrame):
         all_results = {}; overall = []; last = None; bars = {}
         for p in presets:
             results = self.runner.run_test(self.core, p, repeats=repeats, save_plot_dir=out_dir if self.save_plots_var.get() else None)
-            delays = [r for r in results if r is not None]
-            all_results[p["name"]] = {"per_sound_baseline_ms": self.cfg["per_sound_offsets_ms"].get(p["key"], 0.0), "delays_ms": delays}
-            bars[p["name"]] = delays
-            if delays: overall.extend(delays); last = delays[-1]
+            l = results["left_ms"]
+            r = results["right_ms"]
+            avg = results["avg_ms"]
+            diff = results["diff_ms"]
+            all_results[p["name"]] = {
+                "per_sound_baseline_ms": self.cfg["per_sound_offsets_ms"].get(p["key"], 0.0),
+                "left_ms": l,
+                "right_ms": r,
+                "avg_ms": avg,
+                "diff_ms": diff,
+            }
+            bars[p["name"]] = avg
+            if avg:
+                overall.extend(avg)
+                last = avg[-1]
 
         self.last_all_results = all_results
         self._refresh_summary(all_results)
@@ -171,10 +182,17 @@ class LatencyPage(ctk.CTkScrollableFrame):
         global_off = float(self.cfg.get("global_system_offset_ms", 0.0))
         now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-        overall_delays = [d for v in all_results.values() for d in v["delays_ms"]]
-        overall_avg = np.mean(overall_delays) if overall_delays else 0.0
-        overall_std = np.std(overall_delays) if overall_delays else 0.0
-        total_success = len(overall_delays)
+        overall_left = [d for v in all_results.values() for d in v["left_ms"]]
+        overall_right = [d for v in all_results.values() for d in v["right_ms"]]
+        overall_diff = [d for v in all_results.values() for d in v["diff_ms"]]
+        overall_avg_list = [d for v in all_results.values() for d in v["avg_ms"]]
+        overall_avg_L = float(np.mean(overall_left)) if overall_left else 0.0
+        overall_avg_R = float(np.mean(overall_right)) if overall_right else 0.0
+        overall_avg_diff = float(np.mean(overall_diff)) if overall_diff else 0.0
+        overall_std_diff = float(np.std(overall_diff)) if overall_diff else 0.0
+        overall_avg = float(np.mean(overall_avg_list)) if overall_avg_list else 0.0
+        overall_std = float(np.std(overall_avg_list)) if overall_avg_list else 0.0
+        total_success = len(overall_avg_list)
 
         lines = [
             "="*60,
@@ -189,8 +207,11 @@ class LatencyPage(ctk.CTkScrollableFrame):
             "",
             "",
             "==================== OVERALL AVERAGE CALIBRATED DELAY (ALL SOUND TYPES) ====================",
-            f"Overall Average Calibrated Delay: {overall_avg:.4f} ms",
-            f"Overall Standard Deviation: {overall_std:.4f} ms",
+            f"Overall Average Calibrated Delay: L {overall_avg_L:.4f} ms | R {overall_avg_R:.4f} ms",
+            f"Overall Average Difference (L-R): {overall_avg_diff:.4f} ms",
+            f"Std Dev of Difference: {overall_std_diff:.4f} ms",
+            f"Overall Average (L&R): {overall_avg:.4f} ms",
+            f"Overall Standard Deviation (avg): {overall_std:.4f} ms",
             f"Total Successful Tests: {total_success}",
             "="*60,
             "",
@@ -201,35 +222,37 @@ class LatencyPage(ctk.CTkScrollableFrame):
             if name not in all_results:
                 continue
             data = all_results[name]
-            delays = data["delays_ms"]
+            l = data["left_ms"]
+            r = data["right_ms"]
+            diff = data["diff_ms"]
             lines.append(f"==================== Results for '{name}' ====================")
             lines.append("Individual test results (Calibrated):")
             lines.append("------------------------------")
-            for i, d in enumerate(delays, 1):
-                lines.append(f"Test {i}: {d:.4f} ms")
+            for i in range(len(l)):
+                lines.append(f"Test {i+1}: L {l[i]:.4f} ms | R {r[i]:.4f} ms | Δ {diff[i]:.4f} ms")
             lines.append("")
             lines.append(f"STATISTICAL ANALYSIS for '{name}' (Calibrated):")
             lines.append("------------------------------")
-            if delays:
-                avg = float(np.mean(delays))
-                std = float(np.std(delays))
-                mn = float(np.min(delays))
-                mx = float(np.max(delays))
-                rng = mx - mn
+            if l and r:
+                avg_l = float(np.mean(l)); std_l = float(np.std(l))
+                avg_r = float(np.mean(r)); std_r = float(np.std(r))
+                avg_diff = float(np.mean(diff)); std_diff = float(np.std(diff))
                 lines.extend([
-                    f"Average calibrated delay: {avg:.4f} ms",
-                    f"Standard deviation: {std:.4f} ms",
-                    f"Minimum calibrated delay: {mn:.4f} ms",
-                    f"Maximum calibrated delay: {mx:.4f} ms",
-                    f"Range: {rng:.4f} ms",
+                    f"Average L delay: {avg_l:.4f} ms",
+                    f"Std Dev L: {std_l:.4f} ms",
+                    f"Average R delay: {avg_r:.4f} ms",
+                    f"Std Dev R: {std_r:.4f} ms",
+                    f"Average difference (L-R): {avg_diff:.4f} ms",
+                    f"Std Dev difference: {std_diff:.4f} ms",
                 ])
             else:
-                avg = std = None
+                avg_l = avg_r = None
                 lines.append("No successful runs")
             lines.append("")
             lines.append(f"PERFORMANCE ASSESSMENT for '{name}' (Calibrated):")
             lines.append("------------------------------")
-            if avg is not None:
+            if avg_l is not None and avg_r is not None:
+                avg = float(np.mean([avg_l, avg_r]))
                 perf_label, perf_desc = self._performance_label(avg)
                 lines.append(f"Performance: {perf_label}")
                 lines.append(perf_desc)
@@ -238,18 +261,21 @@ class LatencyPage(ctk.CTkScrollableFrame):
             lines.append("")
             lines.append(f"CONSISTENCY ANALYSIS for '{name}':")
             lines.append("------------------------------")
-            if std is not None:
-                cons_label = self._consistency_label(std)
+            if avg_l is not None and avg_r is not None:
+                std_avg = float(np.mean([std_l, std_r]))
+                cons_label = self._consistency_label(std_avg)
                 lines.append(f"Consistency: {cons_label}")
             else:
                 lines.append("Consistency: N/A")
             lines.append("")
             lines.append(f"RAW DATA (Calibrated Delays for '{name}'):")
             lines.append("------------------------------")
-            if delays:
-                lines.append("Delays (ms): " + ", ".join(f"{d:.4f}" for d in delays))
+            if l and r:
+                lines.append("L (ms): " + ", ".join(f"{x:.4f}" for x in l))
+                lines.append("R (ms): " + ", ".join(f"{x:.4f}" for x in r))
+                lines.append("Δ (ms): " + ", ".join(f"{x:.4f}" for x in diff))
             else:
-                lines.append("Delays (ms): none")
+                lines.append("No data")
             lines.append("")
 
         lines.append("="*60)
@@ -287,9 +313,13 @@ class LatencyPage(ctk.CTkScrollableFrame):
     def _refresh_summary(self, all_results):
         lines = ["=== SUMMARY (Calibrated) ==="]
         for name, data in all_results.items():
-            dd = data["delays_ms"]
-            if dd: lines.append(f"{name}: avg {np.mean(dd):.2f} ms | std {np.std(dd):.2f} | n {len(dd)}")
-            else: lines.append(f"{name}: no successful runs")
+            l = data["left_ms"]
+            r = data["right_ms"]
+            diff = data["diff_ms"]
+            if l and r:
+                lines.append(f"{name}: L {np.mean(l):.2f} ms | R {np.mean(r):.2f} ms | Δ {np.mean(diff):.2f} ms")
+            else:
+                lines.append(f"{name}: no successful runs")
         self.summary_box.delete("1.0", "end"); self.summary_box.insert("1.0", "\n".join(lines))
 
     def _refresh_baseline_box(self):


### PR DESCRIPTION
## Summary
- record stereo for isolation and latency while reverting other experiments to mono
- compute and report latency per channel with difference stats and per-channel plots
- capture isolation metrics for both left and right earcups simultaneously

## Testing
- `python -m py_compile app/experimental_tests/balance.py app/experimental_tests/crosstalk.py app/experimental_tests/thd.py app/experimental_tests/isolation.py app/tests/latency.py app/ui/pages/latency_page.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c702eeac83338f4aa34ca4d53d72