### PR TITLE
Organize sweep FR modules

### DIFF
--- a/app/tests/__init__.py
+++ b/app/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Test utilities for Pawdio Lab."""
+
+from . import sweep_fr
+
+__all__ = ["sweep_fr"]

--- a/app/tests/sweep_fr/__init__.py
+++ b/app/tests/sweep_fr/__init__.py
@@ -1,0 +1,6 @@
+"""Sweep frequency response test utilities."""
+
+from .sweep_fr import run
+from .input_monitor import InputMonitorController, LevelState
+
+__all__ = ["run", "InputMonitorController", "LevelState"]

--- a/app/tests/sweep_fr/input_monitor.py
+++ b/app/tests/sweep_fr/input_monitor.py
@@ -1,0 +1,193 @@
+"""Threaded input level monitoring utilities for the UI."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+import numpy as np
+
+from app.core.utils import dbfs
+
+
+@dataclass
+class LevelState:
+    """Thread-safe container for meter levels."""
+
+    current_level: float = -96.0
+    peak_level: float = -96.0
+    clip_count: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    def record_sample(self, rms_dbfs: float, peak_dbfs: float, clipped: bool = False) -> None:
+        """Store a new measurement from the monitor thread."""
+        rms_dbfs = float(max(-96.0, min(rms_dbfs, 0.0)))
+        peak_dbfs = float(max(-96.0, min(peak_dbfs, 0.0)))
+        with self._lock:
+            self.current_level = rms_dbfs
+            if peak_dbfs > self.peak_level:
+                self.peak_level = peak_dbfs
+            if clipped:
+                self.clip_count += 1
+
+    def assign(self, rms_dbfs: float, peak_dbfs: Optional[float] = None, clip_count: Optional[int] = None) -> None:
+        """Assign levels from an external source (e.g. pink noise playback)."""
+        rms_dbfs = float(max(-96.0, min(rms_dbfs, 0.0)))
+        with self._lock:
+            self.current_level = rms_dbfs
+            if peak_dbfs is not None:
+                peak_dbfs = float(max(-96.0, min(peak_dbfs, 0.0)))
+                self.peak_level = peak_dbfs
+            if clip_count is not None:
+                self.clip_count = clip_count
+
+    def reset_peak(self) -> None:
+        with self._lock:
+            self.peak_level = -96.0
+            self.clip_count = 0
+
+    def snapshot(self) -> tuple[float, float, int]:
+        with self._lock:
+            return self.current_level, self.peak_level, self.clip_count
+
+
+class InputMonitorController:
+    """Manage the lifetime of the input monitoring thread."""
+
+    def __init__(
+        self,
+        core,
+        level_state: LevelState,
+        *,
+        ui_dispatch: Callable[[Callable[..., None]], None],
+        on_start: Optional[Callable[[], None]] = None,
+        on_stop: Optional[Callable[[], None]] = None,
+        on_error: Optional[Callable[[Exception], None]] = None,
+        log_fn: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self.core = core
+        self.level_state = level_state
+        self._ui_dispatch = ui_dispatch
+        self._on_start = on_start
+        self._on_stop = on_stop
+        self._on_error = on_error
+        self._log = log_fn or (lambda message: None)
+
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._stream_lock = threading.Lock()
+        self._stream = None
+
+    @property
+    def is_running(self) -> bool:
+        thread = self._thread
+        return thread is not None and thread.is_alive()
+
+    def start(self) -> None:
+        if self.is_running:
+            return
+        self._stop_event.clear()
+        thread = threading.Thread(target=self._run, daemon=True)
+        self._thread = thread
+        thread.start()
+
+    def stop(self) -> None:
+        thread = self._thread
+        if thread is None:
+            return
+
+        self._stop_event.set()
+        with self._stream_lock:
+            stream = self._stream
+        if stream is not None:
+            try:
+                stream.stop_stream()
+            except Exception:
+                pass
+        thread.join(timeout=3.0)
+
+    # Internal helpers -------------------------------------------------
+    def _dispatch_ui(self, callback: Optional[Callable[..., None]], *args) -> None:
+        if callback is None:
+            return
+
+        def runner() -> None:
+            callback(*args)
+
+        self._ui_dispatch(runner)
+
+    def _run(self) -> None:
+        chunk = int(getattr(self.core, "chunk_size", 1024))
+        samplerate = int(getattr(self.core, "input_sample_rate", getattr(self.core, "sample_rate", 44100)))
+        fmt = self.core.audio.get_format_from_width(2)
+        channels_in_use = 1
+        stream = None
+        last_exc: Optional[Exception] = None
+        try:
+            for ch in (1, 2):
+                try:
+                    stream = self.core.audio.open(
+                        format=fmt,
+                        channels=ch,
+                        rate=samplerate,
+                        input=True,
+                        frames_per_buffer=chunk,
+                        input_device_index=self.core.input_device_index,
+                    )
+                    channels_in_use = ch
+                    break
+                except Exception as exc:  # pragma: no cover - hardware dependent
+                    stream = None
+                    last_exc = exc
+                    continue
+            if stream is None:
+                if last_exc is not None:
+                    raise RuntimeError("Unable to open input stream for monitoring") from last_exc
+                raise RuntimeError("Unable to open input stream for monitoring")
+
+            with self._stream_lock:
+                self._stream = stream
+            self._dispatch_ui(self._on_start)
+
+            while not self._stop_event.is_set():
+                try:
+                    data = stream.read(chunk, exception_on_overflow=False)
+                except Exception as exc:
+                    if self._stop_event.is_set():
+                        break
+                    raise exc
+                if not data:
+                    continue
+                audio = np.frombuffer(data, dtype=np.int16).astype(np.float32) / 32768.0
+                if channels_in_use > 1 and audio.size:
+                    try:
+                        audio = audio.reshape(-1, channels_in_use).mean(axis=1)
+                    except ValueError:
+                        audio = audio.reshape(-1)
+                if audio.size == 0:
+                    continue
+                rms_level = dbfs(audio)
+                peak_level = 20 * np.log10(max(float(np.max(np.abs(audio))), 1e-12))
+                clipped = peak_level >= -1.0
+                self.level_state.record_sample(rms_level, peak_level, clipped)
+        except Exception as exc:  # pragma: no cover - depends on hardware availability
+            self._log(f"Input monitor error: {exc}")
+            self._dispatch_ui(self._on_error, exc)
+        finally:
+            with self._stream_lock:
+                active_stream = self._stream
+                self._stream = None
+            if active_stream is not None:
+                try:
+                    if active_stream.is_active():
+                        active_stream.stop_stream()
+                except Exception:
+                    pass
+                try:
+                    active_stream.close()
+                except Exception:
+                    pass
+            self._dispatch_ui(self._on_stop)
+            self._thread = None
+            self._stop_event.clear()

--- a/app/tests/sweep_fr/sweep_fr.py
+++ b/app/tests/sweep_fr/sweep_fr.py
@@ -2,9 +2,9 @@ import os, datetime, numpy as np, matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from scipy import signal
-from ..core.audio import AudioCore
-from ..core.utils import ensure_dir
-from .base import TestResult
+from app.core.audio import AudioCore
+from app.core.utils import ensure_dir
+from ..base import TestResult
 
 from tkinter import messagebox
 

--- a/app/ui/pages/sweep_fr_page.py
+++ b/app/ui/pages/sweep_fr_page.py
@@ -4,7 +4,8 @@ import time
 import importlib
 import numpy as np
 from ...tests import sweep_fr
-from ...core.utils import ensure_dir, dbfs
+from ...core.utils import ensure_dir
+from ...tests.sweep_fr import InputMonitorController, LevelState
 
 _sounddevice_spec = importlib.util.find_spec("sounddevice")
 sounddevice = importlib.import_module("sounddevice") if _sounddevice_spec else None
@@ -16,9 +17,17 @@ class SweepFRPage(ctk.CTkFrame):
         self.cfg = cfg
         self.log = log_fn
         self.results = []
-        self.monitoring = False
-        self.monitor_thread = None
-        self.monitor_stream = None
+        self.level_state = LevelState()
+        self.monitor_controller = InputMonitorController(
+            self.core,
+            self.level_state,
+            ui_dispatch=self._dispatch_to_ui,
+            on_start=self._on_monitor_started,
+            on_stop=self._on_monitor_stopped,
+            on_error=self._handle_monitor_error,
+            log_fn=self.log,
+        )
+        self._monitor_error = False
 
         self.pink_noise_playing = False
         self.pink_noise_thread = None
@@ -91,10 +100,6 @@ class SweepFRPage(ctk.CTkFrame):
         self._build_level_monitor().grid(row=2, column=0, padx=18, pady=12, sticky="nsew")
         self._build_results().grid(row=2, column=1, padx=18, pady=12, sticky="nsew")
 
-        # Initialize level tracking (no recorder used!)
-        self.current_level = -96.0
-        self.peak_level = -96.0
-        self.clip_count = 0
         self.after(100, self._update_meter_display)
 
     def _choose_outdir(self):
@@ -212,120 +217,74 @@ class SweepFRPage(ctk.CTkFrame):
 
     # ===== Monitoring System =====
     def toggle_monitoring(self):
-        if self.monitoring:
-            self.monitoring = False
-            self.monitor_button.configure(text="Start Monitoring")
-            self.status_label.configure(text="Monitoring stopped.")
-            if self.monitor_stream is not None:
-                try:
-                    self.monitor_stream.stop_stream()
-                except Exception:
-                    pass
-                try:
-                    self.monitor_stream.close()
-                except Exception:
-                    pass
-                self.monitor_stream = None
+        if self.monitor_controller.is_running:
+            self._stop_monitoring()
         else:
-            self.monitoring = True
-            self.monitor_button.configure(text="Stop Monitoring")
-            self.status_label.configure(text="Monitoring input...")
-            if self.monitor_thread and self.monitor_thread.is_alive():
-                return
-            self.monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
-            self.monitor_thread.start()
+            self._start_monitoring()
 
-    def _monitor_loop(self):
-        chunk = int(getattr(self.core, "chunk_size", 1024))
-        samplerate = int(getattr(self.core, "input_sample_rate", getattr(self.core, "sample_rate", 44100)))
-        fmt = self.core.audio.get_format_from_width(2)
-        stream = None
-        channels_in_use = 1
-        error = False
+    def _start_monitoring(self):
+        if self.monitor_controller.is_running:
+            return
+        self.monitor_button.configure(state="disabled")
+        self.status_label.configure(text="Starting monitor...")
+        self._monitor_error = False
         try:
-            for ch in (1, 2):
-                try:
-                    stream = self.core.audio.open(
-                        format=fmt,
-                        channels=ch,
-                        rate=samplerate,
-                        input=True,
-                        frames_per_buffer=chunk,
-                        input_device_index=self.core.input_device_index,
-                    )
-                    channels_in_use = ch
-                    break
-                except Exception:
-                    stream = None
-                    continue
-            if stream is None:
-                raise RuntimeError("Unable to open input stream for monitoring")
-            self.monitor_stream = stream
-            while self.monitoring:
-                data = stream.read(chunk, exception_on_overflow=False)
-                if not data:
-                    continue
-                audio = np.frombuffer(data, dtype=np.int16).astype(np.float32) / 32768.0
-                if channels_in_use > 1:
-                    try:
-                        audio = audio.reshape(-1, channels_in_use).mean(axis=1)
-                    except ValueError:
-                        audio = audio.reshape(-1)
-                if audio.size == 0:
-                    continue
-                rms_level = dbfs(audio)
-                peak_level = 20 * np.log10(max(np.max(np.abs(audio)), 1e-12))
-                rms_level = max(-96.0, min(rms_level, 0.0))
-                peak_level = max(-96.0, min(peak_level, 0.0))
-                self.current_level = rms_level
-                if peak_level > self.peak_level:
-                    self.peak_level = peak_level
-                if peak_level >= -1.0:
-                    self.clip_count += 1
-        except Exception as e:
-            if self.monitoring:
-                error = True
-                self.after(0, lambda err=e: self._handle_monitor_error(err))
-        finally:
-            if stream is not None:
-                try:
-                    stream.stop_stream()
-                except Exception:
-                    pass
-                try:
-                    stream.close()
-                except Exception:
-                    pass
-            self.monitor_stream = None
-            self.monitor_thread = None
-            self.monitoring = False
-            if not error:
-                self.after(0, lambda: self.status_label.configure(text="Monitoring stopped."))
-            self.after(0, lambda: self.monitor_button.configure(text="Start Monitoring"))
+            self.monitor_controller.start()
+        except Exception as err:  # pragma: no cover - defensive
+            self._handle_monitor_error(err)
+            self.monitor_button.configure(state="normal")
+
+    def _stop_monitoring(self):
+        if not self.monitor_controller.is_running:
+            self._on_monitor_stopped()
+            return
+        self.monitor_button.configure(state="disabled")
+        self.status_label.configure(text="Stopping monitor...")
+
+        def _stop() -> None:
+            self.monitor_controller.stop()
+
+        threading.Thread(target=_stop, daemon=True).start()
+
+    def _on_monitor_started(self):
+        self._monitor_error = False
+        self.monitor_button.configure(text="Stop Monitoring", state="normal")
+        self.status_label.configure(text="Monitoring input...")
+
+    def _on_monitor_stopped(self):
+        self.monitor_button.configure(text="Start Monitoring", state="normal")
+        if not self._monitor_error:
+            self.status_label.configure(text="Monitoring stopped.")
 
     def _handle_monitor_error(self, err):
+        self._monitor_error = True
         self.log(f"Error in monitoring: {err}")
         traceback.print_exc()
         self.status_label.configure(text="Monitor error. Check input device.")
-        self.monitor_button.configure(text="Start Monitoring")
+        self.monitor_button.configure(text="Start Monitoring", state="normal")
+
+    def _dispatch_to_ui(self, callback):
+        if callback is None:
+            return
+        self.after(0, callback)
 
     def _update_meter_display(self):
         self.level_canvas.delete("all")
-        bar_w = max(0, (self.current_level + 96) / 96 * self.level_canvas.winfo_width())
-        color = "green" if self.current_level < -3 else "red"
+        current_level, peak_level, clip_count = self.level_state.snapshot()
+        bar_w = max(0, (current_level + 96) / 96 * self.level_canvas.winfo_width())
+        color = "green" if current_level < -3 else "red"
         self.level_canvas.create_rectangle(0, 0, bar_w, 60, fill=color, width=0)
-        self.current_level_label.configure(text=f"{self.current_level:.1f} dBFS")
-        self.peak_level_label.configure(text=f"{self.peak_level:.1f} dBFS")
-        self.spl_label.configure(text=f"{self.current_level+94:.1f} dB SPL")
-        if self.clip_count > 0:
-            self.clip_warning.configure(text=f"Clipping! ({self.clip_count})")
+        self.current_level_label.configure(text=f"{current_level:.1f} dBFS")
+        self.peak_level_label.configure(text=f"{peak_level:.1f} dBFS")
+        self.spl_label.configure(text=f"{current_level+94:.1f} dB SPL")
+        if clip_count > 0:
+            self.clip_warning.configure(text=f"Clipping! ({clip_count})")
         else:
             self.clip_warning.configure(text="")
         self.after(100, self._update_meter_display)
 
     def reset_peak(self):
-        self.peak_level = -96.0
-        self.clip_count = 0
+        self.level_state.reset_peak()
 
     # ===== Pink Noise Playback/Monitoring =====
     def toggle_pink_noise(self):
@@ -364,12 +323,10 @@ class SweepFRPage(ctk.CTkFrame):
             # Real-time measurement (simulate level from pink noise itself)
             rms = np.sqrt(np.mean(pink ** 2))
             dbfs = 20 * np.log10(rms + 1e-12)
-            if not self.monitoring:
-                self.current_level = dbfs
-                if dbfs > self.peak_level:
-                    self.peak_level = dbfs
-                if dbfs >= -3.0:
-                    self.clip_count += 1
+            if not self.monitor_controller.is_running:
+                peak = 20 * np.log10(np.max(np.abs(pink)) + 1e-12)
+                clip = peak >= -3.0
+                self.level_state.record_sample(dbfs, peak, clip)
 
         if sounddevice is None:
             return


### PR DESCRIPTION
## Summary
- move the sweep frequency response logic into a dedicated app/tests/sweep_fr package
- relocate the input monitor controller alongside the sweep code and re-export the helpers
- update the UI sweep page to reference the new package layout

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d4925c70483339d19028219b5d491)