### PR TITLE
Refresh UI theming and layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ PawdioLab is a simple desktop toolkit for measuring and visualising audio latenc
 - **Device management** – Discover input/output devices, supported sample rates, and configure audio hardware prior to running tests.(Currently very buggy and unusable)
 - **Results export** – Save per-sound plots, bar charts, and text summaries for later analysis.
 - **Experimental labs** – Optional playgrounds for work-in-progress measurements that can be toggled from settings.(THD, Isolation, Channel Balance and such)
+
+## Appearance & theming
+
+You can adjust PawdioLab's look and feel from the **Devices / Settings** page. The **Appearance** dropdown switches between Dark, Light, and System modes, while the **Accent** dropdown selects one of the bundled colour themes (Greyscale, Blue, Teal, Purple). Changes apply immediately across the app and are stored in `~/.pawdiolab/theme.json` so your preferred styling loads automatically next time you launch PawdioLab.

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -5,7 +5,13 @@ from pathlib import Path
 import tkinter as tk  # for PhotoImage on mac/linux
 import customtkinter as ctk
 
-from .theme import apply_theme
+from .theme import (
+    ThemeConfig,
+    apply_theme,
+    load_theme_config,
+    save_theme_config,
+    theme_from_legacy,
+)
 from ..config import load_config, save_config
 from ..core.audio import AudioCore
 from .pages.latency_page import LatencyPage
@@ -58,8 +64,19 @@ if not ICON_PATHS:
 
 class MainApp(ctk.CTk):
     def __init__(self):
+        self.theme = load_theme_config()
         self.cfg = load_config()
-        apply_theme(self.cfg["ui"])
+
+        legacy_theme = theme_from_legacy(self.cfg.get("ui"))
+        if self.theme == ThemeConfig() and legacy_theme != ThemeConfig():
+            self.theme = legacy_theme
+            save_theme_config(self.theme)
+
+        apply_theme(self.theme)
+        self.cfg.setdefault("ui", {})
+        self.cfg["ui"]["appearance_mode"] = self.theme.appearance_mode
+        self.cfg["ui"]["accent"] = self.theme.accent
+        self.cfg["ui"]["color_theme"] = self.theme.accent
 
         super().__init__()
 
@@ -137,6 +154,8 @@ class MainApp(ctk.CTk):
             self.cfg,
             self._log,
             on_toggle_experimental=self._toggle_experimental,
+            theme_config=self.theme,
+            on_theme_change=self._apply_new_theme,
         )
         self.pages["results"] = ResultsPage(self.main, self._log_sink)
 
@@ -144,6 +163,19 @@ class MainApp(ctk.CTk):
             self._add_experimental_page()
 
         self._show("latency")
+
+    def _apply_new_theme(self, theme: ThemeConfig) -> None:
+        if theme == self.theme:
+            return
+
+        self.theme = theme
+        apply_theme(theme)
+        save_theme_config(theme)
+        self.cfg.setdefault("ui", {})
+        self.cfg["ui"]["appearance_mode"] = theme.appearance_mode
+        self.cfg["ui"]["accent"] = theme.accent
+        self.cfg["ui"]["color_theme"] = theme.accent
+        save_config(self.cfg)
 
     def _set_window_icon(self):
         if not ICON_PATHS:

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -88,12 +88,14 @@ class MainApp(ctk.CTk):
         self.minsize(1060, 720)
 
         # layout
-        self.grid_columnconfigure(1, weight=1)
+        self.grid_columnconfigure(0, weight=1, minsize=260)
+        self.grid_columnconfigure(1, weight=5)
         self.grid_rowconfigure(0, weight=1)
 
-        self.sidebar = ctk.CTkFrame(self, corner_radius=0, width=230)
-        self.sidebar.grid(row=0, column=0, sticky="nsw")
+        self.sidebar = ctk.CTkFrame(self, corner_radius=0, width=260)
+        self.sidebar.grid(row=0, column=0, sticky="nswe")
         self.sidebar.grid_rowconfigure(10, weight=1)
+        self.sidebar.grid_columnconfigure(0, weight=1)
 
         ctk.CTkLabel(
             self.sidebar,
@@ -163,13 +165,14 @@ class MainApp(ctk.CTk):
             self._add_experimental_page()
 
         self._show("latency")
+        apply_theme(self.theme, self)
 
     def _apply_new_theme(self, theme: ThemeConfig) -> None:
         if theme == self.theme:
             return
 
         self.theme = theme
-        apply_theme(theme)
+        apply_theme(theme, self)
         save_theme_config(theme)
         self.cfg.setdefault("ui", {})
         self.cfg["ui"]["appearance_mode"] = theme.appearance_mode

--- a/app/ui/pages/devices_page.py
+++ b/app/ui/pages/devices_page.py
@@ -1,65 +1,193 @@
-
 import customtkinter as ctk
+
 from ...config import save_config
+from ..theme import ThemeConfig, available_accents
+
 
 class DevicesPage(ctk.CTkFrame):
-    def __init__(self, master, core, cfg, log_fn, on_toggle_experimental):
+    def __init__(
+        self,
+        master,
+        core,
+        cfg,
+        log_fn,
+        on_toggle_experimental,
+        *,
+        theme_config: ThemeConfig,
+        on_theme_change,
+    ):
         super().__init__(master, corner_radius=0)
-        self.core = core; self.cfg = cfg; self.log = log_fn; self.on_toggle_experimental = on_toggle_experimental
-        self.grid_columnconfigure(1, weight=1)
+        self.core = core
+        self.cfg = cfg
+        self.log = log_fn
+        self.on_toggle_experimental = on_toggle_experimental
+        self.theme_config = theme_config
+        self.theme_callback = on_theme_change
 
-        ctk.CTkLabel(self, text="Devices / Settings", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, columnspan=2, padx=18, pady=(18,4), sticky="w")
+        self.section_font = ctk.CTkFont(size=14, weight="bold")
+        self.page_title_font = ctk.CTkFont(size=20, weight="bold")
+        self.button_style = {"height": 36, "corner_radius": 8}
 
-        card = ctk.CTkFrame(self); card.grid(row=1, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        for i in range(7): card.grid_columnconfigure(i, weight=1)
-        ctk.CTkLabel(card, text="Output Sample Rate").grid(row=0, column=0, padx=8, pady=8, sticky="w")
-        self.out_sr_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("output_sample_rate", 44100)))
-        self.out_sr_menu = ctk.CTkOptionMenu(card, values=[], variable=self.out_sr_var, width=120)
-        self.out_sr_menu.grid(row=0, column=1, padx=8, pady=8, sticky="w")
-        ctk.CTkLabel(card, text="Input Sample Rate").grid(row=0, column=2, padx=8, pady=8, sticky="w")
-        self.in_sr_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("input_sample_rate", 44100)))
-        self.in_sr_menu = ctk.CTkOptionMenu(card, values=[], variable=self.in_sr_var, width=120)
-        self.in_sr_menu.grid(row=0, column=3, padx=8, pady=8, sticky="w")
-        ctk.CTkLabel(card, text="Signal Duration (s)").grid(row=0, column=4, padx=8, pady=8, sticky="w")
-        self.dur_var = ctk.DoubleVar(value=self.cfg["last_settings"]["duration"])
-        ctk.CTkEntry(card, textvariable=self.dur_var, width=120).grid(row=0, column=5, padx=8, pady=8, sticky="w")
-        ctk.CTkButton(card, text="Apply", command=self._apply).grid(row=0, column=6, padx=8, pady=8, sticky="e")
-        self.out_bits_label = ctk.CTkLabel(card, text="Output Bit Depth")
-        self.out_bits_label.grid(row=1, column=0, padx=8, pady=8, sticky="w")
-        self.out_bits_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("output_bit_depth", "")))
-        self.out_bits_menu = ctk.CTkOptionMenu(card, values=[], variable=self.out_bits_var, width=120)
-        self.out_bits_menu.grid(row=1, column=1, padx=8, pady=8, sticky="w")
-        self.in_bits_label = ctk.CTkLabel(card, text="Input Bit Depth")
-        self.in_bits_label.grid(row=1, column=2, padx=8, pady=8, sticky="w")
-        self.in_bits_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("input_bit_depth", "")))
-        self.in_bits_menu = ctk.CTkOptionMenu(card, values=[], variable=self.in_bits_var, width=120)
-        self.in_bits_menu.grid(row=1, column=3, padx=8, pady=8, sticky="w")
-        self.out_bits_label.grid_remove(); self.out_bits_menu.grid_remove()
-        self.in_bits_label.grid_remove(); self.in_bits_menu.grid_remove()
+        self.accent_options = available_accents()
+        self.accent_display_to_key = {v: k for k, v in self.accent_options.items()}
 
-        dev = ctk.CTkFrame(self); dev.grid(row=2, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        dev.grid_columnconfigure(1, weight=1)
-        ctk.CTkLabel(dev, text="Output Device").grid(row=0, column=0, padx=8, pady=(8,4), sticky="w")
-        self.out_menu = ctk.CTkOptionMenu(dev, values=["<refresh>"], command=lambda _: self._update_sr_menus()); self.out_menu.grid(row=0, column=1, padx=8, pady=(8,4), sticky="ew")
-        ctk.CTkLabel(dev, text="Input Device").grid(row=1, column=0, padx=8, pady=(4,8), sticky="w")
-        self.in_menu = ctk.CTkOptionMenu(dev, values=["<refresh>"], command=lambda _: self._update_sr_menus()); self.in_menu.grid(row=1, column=1, padx=8, pady=(4,8), sticky="ew")
-        ctk.CTkButton(dev, text="Refresh Devices", command=self._refresh_devices).grid(row=0, column=2, rowspan=2, padx=8)
+        self.grid_columnconfigure(0, weight=1)
 
-        ap = ctk.CTkFrame(self); ap.grid(row=3, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        ap.grid_columnconfigure(3, weight=1)
-        ctk.CTkLabel(ap, text="Appearance").grid(row=0, column=0, padx=8, pady=8, sticky="w")
-        self.appearance = ctk.CTkOptionMenu(ap, values=["Light","Dark","System"]); self.appearance.set(self.cfg["ui"].get("appearance_mode", "Dark")); self.appearance.grid(row=0, column=1, padx=8, sticky="w")
-        ctk.CTkLabel(ap, text="Accent").grid(row=0, column=2, padx=8, pady=8, sticky="w")
-        self.color = ctk.CTkOptionMenu(ap, values=["blue","dark-blue","green"]); self.color.set(self.cfg["ui"].get("color_theme","blue")); self.color.grid(row=0, column=3, padx=8, sticky="w")
+        ctk.CTkLabel(
+            self,
+            text="Devices / Settings",
+            font=self.page_title_font,
+        ).grid(row=0, column=0, padx=24, pady=(24, 12), sticky="w")
 
-        self.experimental_var = ctk.BooleanVar(value=bool(self.cfg["ui"].get("labs_enabled", True)))
-        ctk.CTkSwitch(ap, text="Enable Experimental Tests", variable=self.experimental_var, command=self._toggle_experimental).grid(row=1, column=0, columnspan=2, padx=8, pady=(8,6), sticky="w")
+        self._build_signal_settings(row=1)
+        self._build_device_selection(row=2)
+        self._build_appearance_settings(row=3)
 
         self._refresh_devices()
 
+    def _build_signal_settings(self, row: int) -> None:
+        frame = ctk.CTkFrame(self)
+        frame.grid(row=row, column=0, sticky="ew", padx=24, pady=(12, 16))
+        frame.grid_columnconfigure((1, 3), weight=1)
+
+        ctk.CTkLabel(frame, text="Signal Settings", font=self.section_font).grid(
+            row=0, column=0, columnspan=4, sticky="w", padx=18, pady=(16, 10)
+        )
+
+        self.out_sr_var = ctk.StringVar(
+            value=str(self.cfg["last_settings"].get("output_sample_rate", 44100))
+        )
+        ctk.CTkLabel(frame, text="Output Sample Rate").grid(
+            row=1, column=0, sticky="w", padx=(18, 8), pady=(0, 8)
+        )
+        self.out_sr_menu = ctk.CTkOptionMenu(frame, values=[], variable=self.out_sr_var, width=150)
+        self.out_sr_menu.grid(row=1, column=1, sticky="ew", padx=(0, 18), pady=(0, 8))
+
+        self.in_sr_var = ctk.StringVar(
+            value=str(self.cfg["last_settings"].get("input_sample_rate", 44100))
+        )
+        ctk.CTkLabel(frame, text="Input Sample Rate").grid(
+            row=1, column=2, sticky="w", padx=(18, 8), pady=(0, 8)
+        )
+        self.in_sr_menu = ctk.CTkOptionMenu(frame, values=[], variable=self.in_sr_var, width=150)
+        self.in_sr_menu.grid(row=1, column=3, sticky="ew", padx=(0, 18), pady=(0, 8))
+
+        self.dur_var = ctk.DoubleVar(value=self.cfg["last_settings"]["duration"])
+        ctk.CTkLabel(frame, text="Signal Duration (s)").grid(
+            row=2, column=0, sticky="w", padx=(18, 8), pady=(0, 12)
+        )
+        ctk.CTkEntry(frame, textvariable=self.dur_var).grid(
+            row=2, column=1, sticky="ew", padx=(0, 18), pady=(0, 12)
+        )
+
+        self.out_bits_label = ctk.CTkLabel(frame, text="Output Bit Depth")
+        self.out_bits_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("output_bit_depth", "")))
+        self.out_bits_menu = ctk.CTkOptionMenu(frame, values=[], variable=self.out_bits_var, width=150)
+
+        self.in_bits_label = ctk.CTkLabel(frame, text="Input Bit Depth")
+        self.in_bits_var = ctk.StringVar(value=str(self.cfg["last_settings"].get("input_bit_depth", "")))
+        self.in_bits_menu = ctk.CTkOptionMenu(frame, values=[], variable=self.in_bits_var, width=150)
+
+        self.out_bits_label.grid(row=3, column=0, sticky="w", padx=(18, 8), pady=(0, 12))
+        self.out_bits_menu.grid(row=3, column=1, sticky="ew", padx=(0, 18), pady=(0, 12))
+        self.in_bits_label.grid(row=3, column=2, sticky="w", padx=(18, 8), pady=(0, 12))
+        self.in_bits_menu.grid(row=3, column=3, sticky="ew", padx=(0, 18), pady=(0, 12))
+        self.out_bits_label.grid_remove()
+        self.out_bits_menu.grid_remove()
+        self.in_bits_label.grid_remove()
+        self.in_bits_menu.grid_remove()
+
+        ctk.CTkButton(frame, text="Apply", command=self._apply, **self.button_style).grid(
+            row=2, column=3, sticky="e", padx=(0, 18), pady=(0, 12)
+        )
+
+    def _build_device_selection(self, row: int) -> None:
+        frame = ctk.CTkFrame(self)
+        frame.grid(row=row, column=0, sticky="ew", padx=24, pady=(0, 16))
+        frame.grid_columnconfigure(1, weight=1)
+
+        ctk.CTkLabel(frame, text="Audio Devices", font=self.section_font).grid(
+            row=0, column=0, columnspan=3, sticky="w", padx=18, pady=(16, 10)
+        )
+
+        ctk.CTkLabel(frame, text="Output Device").grid(
+            row=1, column=0, sticky="w", padx=(18, 8), pady=(0, 8)
+        )
+        self.out_menu = ctk.CTkOptionMenu(
+            frame,
+            values=["<refresh>"],
+            command=lambda _: self._update_sr_menus(),
+        )
+        self.out_menu.grid(row=1, column=1, sticky="ew", padx=(0, 12), pady=(0, 8))
+
+        ctk.CTkLabel(frame, text="Input Device").grid(
+            row=2, column=0, sticky="w", padx=(18, 8), pady=(0, 12)
+        )
+        self.in_menu = ctk.CTkOptionMenu(
+            frame,
+            values=["<refresh>"],
+            command=lambda _: self._update_sr_menus(),
+        )
+        self.in_menu.grid(row=2, column=1, sticky="ew", padx=(0, 12), pady=(0, 12))
+
+        ctk.CTkButton(
+            frame,
+            text="Refresh Devices",
+            command=self._refresh_devices,
+            **self.button_style,
+        ).grid(row=1, column=2, rowspan=2, sticky="e", padx=(0, 18), pady=(0, 12))
+
+    def _build_appearance_settings(self, row: int) -> None:
+        frame = ctk.CTkFrame(self)
+        frame.grid(row=row, column=0, sticky="ew", padx=24, pady=(0, 24))
+        frame.grid_columnconfigure((1, 3), weight=1)
+
+        ctk.CTkLabel(frame, text="Appearance", font=self.section_font).grid(
+            row=0, column=0, columnspan=4, sticky="w", padx=18, pady=(16, 10)
+        )
+
+        ctk.CTkLabel(frame, text="Appearance Mode").grid(
+            row=1, column=0, sticky="w", padx=(18, 8), pady=(0, 8)
+        )
+        self.appearance_menu = ctk.CTkOptionMenu(
+            frame,
+            values=["System", "Light", "Dark"],
+            command=self._on_appearance_changed,
+        )
+        self.appearance_menu.set(self.theme_config.appearance_mode)
+        self.appearance_menu.grid(row=1, column=1, sticky="w", padx=(0, 18), pady=(0, 8))
+
+        ctk.CTkLabel(frame, text="Accent Color").grid(
+            row=1, column=2, sticky="w", padx=(18, 8), pady=(0, 8)
+        )
+        accent_display = self.accent_options.get(
+            self.theme_config.accent,
+            self.accent_options[ThemeConfig().accent],
+        )
+        self.accent_menu = ctk.CTkOptionMenu(
+            frame,
+            values=list(self.accent_options.values()),
+            command=self._on_accent_changed,
+        )
+        self.accent_menu.set(accent_display)
+        self.accent_menu.grid(row=1, column=3, sticky="w", padx=(0, 18), pady=(0, 8))
+
+        self.experimental_var = ctk.BooleanVar(
+            value=bool(self.cfg["ui"].get("labs_enabled", True))
+        )
+        ctk.CTkSwitch(
+            frame,
+            text="Enable Experimental Tests",
+            variable=self.experimental_var,
+            command=self._toggle_experimental,
+        ).grid(row=2, column=0, columnspan=4, sticky="w", padx=18, pady=(8, 18))
+
     def _apply(self):
         try:
-            self.core.set_sample_rates(output_rate=int(self.out_sr_menu.get()), input_rate=int(self.in_sr_menu.get()))
+            self.core.set_sample_rates(
+                output_rate=int(self.out_sr_menu.get()),
+                input_rate=int(self.in_sr_menu.get()),
+            )
             self.core.duration = float(self.dur_var.get())
             self.cfg["last_settings"]["output_sample_rate"] = self.core.sample_rate
             self.cfg["last_settings"]["input_sample_rate"] = self.core.input_sample_rate
@@ -69,40 +197,63 @@ class DevicesPage(ctk.CTkFrame):
             if self.in_bits_var.get():
                 self.cfg["last_settings"]["input_bit_depth"] = int(self.in_bits_var.get())
             self.cfg["last_settings"]["duration"] = self.core.duration
-            self.cfg["ui"]["appearance_mode"] = self.appearance.get()
-            self.cfg["ui"]["color_theme"] = self.color.get()
             save_config(self.cfg)
-            self.log(f"[SET] sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}, dur={self.core.duration}s, theme={self.appearance.get()}/{self.color.get()}")
-        except Exception as e:
-            self.log(f"[ERROR] settings: {e}")
+            self.log(
+                f"[SET] sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}, dur={self.core.duration}s"
+            )
+        except Exception as exc:
+            self.log(f"[ERROR] settings: {exc}")
 
     def _refresh_devices(self):
         devs = self.core.list_devices()
         out_values, in_values = [], []
-        self._out_idx = {}; self._in_idx = {}
+        self._out_idx, self._in_idx = {}, {}
         for i, info in enumerate(devs):
-            name = info.get("name","?"); m_in = int(info.get("maxInputChannels",0)); m_out=int(info.get("maxOutputChannels",0)); rate = int(info.get("defaultSampleRate",0))
+            name = info.get("name", "?")
+            m_in = int(info.get("maxInputChannels", 0))
+            m_out = int(info.get("maxOutputChannels", 0))
+            rate = int(info.get("defaultSampleRate", 0))
             label = f"[{i}] {name} (in:{m_in}, out:{m_out}, rate:{rate})"
-            if m_out>0: out_values.append(label); self._out_idx[label]=i
-            if m_in>0: in_values.append(label); self._in_idx[label]=i
-        self.out_menu.configure(values=out_values or ["<no outputs>"]); self.in_menu.configure(values=in_values or ["<no inputs>"])
+            if m_out > 0:
+                out_values.append(label)
+                self._out_idx[label] = i
+            if m_in > 0:
+                in_values.append(label)
+                self._in_idx[label] = i
+        self.out_menu.configure(values=out_values or ["<no outputs>"])
+        self.in_menu.configure(values=in_values or ["<no inputs>"])
+
         out_stored = self.cfg["last_settings"].get("output_device_index")
         in_stored = self.cfg["last_settings"].get("input_device_index")
         out_default = self.core.get_default_output_index()
         in_default = self.core.get_default_input_index()
+
         if out_values:
             target_idx = out_stored if out_stored is not None else out_default
-            target = next((lbl for lbl,idx in self._out_idx.items() if idx==target_idx), out_values[0]); self.out_menu.set(target)
+            target = next(
+                (lbl for lbl, idx in self._out_idx.items() if idx == target_idx),
+                out_values[0],
+            )
+            self.out_menu.set(target)
         if in_values:
             target_idx = in_stored if in_stored is not None else in_default
-            target = next((lbl for lbl,idx in self._in_idx.items() if idx==target_idx), in_values[0]); self.in_menu.set(target)
+            target = next(
+                (lbl for lbl, idx in self._in_idx.items() if idx == target_idx),
+                in_values[0],
+            )
+            self.in_menu.set(target)
         self._update_sr_menus()
 
     def use_selected_devices(self):
-        out_idx = self._out_idx.get(self.out_menu.get()); in_idx = self._in_idx.get(self.in_menu.get())
-        if out_idx is None or in_idx is None: return
+        out_idx = self._out_idx.get(self.out_menu.get())
+        in_idx = self._in_idx.get(self.in_menu.get())
+        if out_idx is None or in_idx is None:
+            return
         self.core.set_devices(output_index=out_idx, input_index=in_idx)
-        self.core.set_sample_rates(output_rate=int(self.out_sr_menu.get()), input_rate=int(self.in_sr_menu.get()))
+        self.core.set_sample_rates(
+            output_rate=int(self.out_sr_menu.get()),
+            input_rate=int(self.in_sr_menu.get()),
+        )
         self.cfg["last_settings"]["output_device_index"] = out_idx
         self.cfg["last_settings"]["input_device_index"] = in_idx
         self.cfg["last_settings"]["output_sample_rate"] = self.core.sample_rate
@@ -111,10 +262,14 @@ class DevicesPage(ctk.CTkFrame):
             self.cfg["last_settings"]["output_bit_depth"] = int(self.out_bits_var.get())
         if self.in_bits_var.get():
             self.cfg["last_settings"]["input_bit_depth"] = int(self.in_bits_var.get())
-        save_config(self.cfg); self.log(f"[SET] devices out={out_idx}, in={in_idx}, sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}")
+        save_config(self.cfg)
+        self.log(
+            f"[SET] devices out={out_idx}, in={in_idx}, sr_out={self.core.sample_rate}, sr_in={self.core.input_sample_rate}"
+        )
 
     def _toggle_experimental(self):
-        self.cfg["ui"]["labs_enabled"] = bool(self.experimental_var.get()); save_config(self.cfg)
+        self.cfg["ui"]["labs_enabled"] = bool(self.experimental_var.get())
+        save_config(self.cfg)
         self.on_toggle_experimental(bool(self.experimental_var.get()))
 
     def _update_sr_menus(self):
@@ -131,6 +286,7 @@ class DevicesPage(ctk.CTkFrame):
 
         stored_out = str(self.cfg["last_settings"].get("output_sample_rate", 44100))
         stored_in = str(self.cfg["last_settings"].get("input_sample_rate", 44100))
+
         def _pick_rate(stored, vals, default_info_idx):
             if stored in vals:
                 return stored
@@ -150,19 +306,46 @@ class DevicesPage(ctk.CTkFrame):
         self.in_bits_menu.configure(values=in_bit_vals)
 
         if len(out_bit_vals) > 1:
-            self.out_bits_label.grid(); self.out_bits_menu.grid()
+            self.out_bits_label.grid()
+            self.out_bits_menu.grid()
             stored = str(self.cfg["last_settings"].get("output_bit_depth", out_bit_vals[0]))
             self.out_bits_menu.set(stored if stored in out_bit_vals else out_bit_vals[0])
         else:
-            self.out_bits_label.grid_remove(); self.out_bits_menu.grid_remove()
+            self.out_bits_label.grid_remove()
+            self.out_bits_menu.grid_remove()
             if out_bit_vals:
                 self.out_bits_var.set(out_bit_vals[0])
 
         if len(in_bit_vals) > 1:
-            self.in_bits_label.grid(); self.in_bits_menu.grid()
+            self.in_bits_label.grid()
+            self.in_bits_menu.grid()
             stored = str(self.cfg["last_settings"].get("input_bit_depth", in_bit_vals[0]))
             self.in_bits_menu.set(stored if stored in in_bit_vals else in_bit_vals[0])
         else:
-            self.in_bits_label.grid_remove(); self.in_bits_menu.grid_remove()
+            self.in_bits_label.grid_remove()
+            self.in_bits_menu.grid_remove()
             if in_bit_vals:
                 self.in_bits_var.set(in_bit_vals[0])
+
+    def _on_appearance_changed(self, value: str) -> None:
+        self._update_theme(appearance=value)
+
+    def _on_accent_changed(self, value: str) -> None:
+        accent_key = self.accent_display_to_key.get(value, self.theme_config.accent)
+        self._update_theme(accent=accent_key)
+
+    def _update_theme(self, *, appearance: str | None = None, accent: str | None = None) -> None:
+        new_theme = ThemeConfig(
+            appearance_mode=appearance or self.theme_config.appearance_mode,
+            accent=accent or self.theme_config.accent,
+        )
+        if new_theme == self.theme_config:
+            return
+        self.theme_config = new_theme
+        self.cfg.setdefault("ui", {})
+        self.cfg["ui"]["appearance_mode"] = new_theme.appearance_mode
+        self.cfg["ui"]["accent"] = new_theme.accent
+        self.cfg["ui"]["color_theme"] = new_theme.accent
+        save_config(self.cfg)
+        self.theme_callback(new_theme)
+        self.log(f"[UI] theme -> {new_theme.appearance_mode}/{new_theme.accent}")

--- a/app/ui/pages/experimental_page.py
+++ b/app/ui/pages/experimental_page.py
@@ -1,46 +1,111 @@
-
 import os, json, customtkinter as ctk
 from ...experimental_tests import balance, crosstalk, thd, isolation
 from ...core.utils import ensure_dir
 
+
 class ExperimentalPage(ctk.CTkFrame):
     def __init__(self, master, core, cfg, log_fn):
         super().__init__(master, corner_radius=0)
-        self.core = core; self.cfg = cfg; self.log = log_fn
+        self.core = core
+        self.cfg = cfg
+        self.log = log_fn
         self.results = []
-        self.grid_columnconfigure(0, weight=1); self.grid_columnconfigure(1, weight=1)
 
-        ctk.CTkLabel(self, text="Experimental Tests", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, columnspan=2, padx=18, pady=(18,4), sticky="w")
+        self.page_title_font = ctk.CTkFont(size=20, weight="bold")
+        self.section_font = ctk.CTkFont(size=14, weight="bold")
+        self.button_style = {"height": 36, "corner_radius": 8}
 
-        bal = ctk.CTkFrame(self); bal.grid(row=1, column=0, padx=18, pady=12, sticky="nsew")
+        self.grid_columnconfigure((0, 1), weight=1)
+
+        ctk.CTkLabel(
+            self,
+            text="Experimental Tests",
+            font=self.page_title_font,
+        ).grid(row=0, column=0, columnspan=2, padx=24, pady=(24, 12), sticky="w")
+
+        cards_container = ctk.CTkFrame(self, fg_color="transparent")
+        cards_container.grid(row=1, column=0, columnspan=2, sticky="nsew", padx=24, pady=(12, 16))
+        cards_container.grid_columnconfigure((0, 1), weight=1)
+        cards_container.grid_rowconfigure((0, 1), weight=1)
+
+        balance_card = ctk.CTkFrame(cards_container, corner_radius=12)
+        balance_card.grid(row=0, column=0, sticky="nsew", padx=12, pady=12)
+        balance_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(balance_card, text="Channel Balance", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        ctk.CTkLabel(balance_card, text="Frequency (Hz)").grid(row=1, column=0, sticky="w", padx=18, pady=(0, 6))
         self.var_bal = ctk.StringVar(value="1000")
-        ctk.CTkLabel(bal, text="Channel Balance").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
-        ctk.CTkLabel(bal, text="Freq (Hz)").grid(row=1, column=0, sticky="w", padx=8)
-        ctk.CTkEntry(bal, textvariable=self.var_bal, width=90).grid(row=1, column=1, sticky="w", padx=8)
-        ctk.CTkButton(bal, text="Run", command=self.on_balance).grid(row=2, column=0, padx=8, pady=8, sticky="w")
+        ctk.CTkEntry(balance_card, textvariable=self.var_bal).grid(row=2, column=0, sticky="ew", padx=18, pady=(0, 12))
+        ctk.CTkButton(balance_card, text="Run", command=self.on_balance, **self.button_style).grid(
+            row=3, column=0, sticky="e", padx=18, pady=(0, 18)
+        )
 
-        xt = ctk.CTkFrame(self); xt.grid(row=1, column=1, padx=18, pady=12, sticky="nsew")
-        self.var_xt = ctk.StringVar(value="1000"); self.var_dir = ctk.StringVar(value="LtoR")
-        ctk.CTkLabel(xt, text="Crosstalk").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
-        ctk.CTkLabel(xt, text="Freq (Hz)").grid(row=1, column=0, sticky="w", padx=8)
-        ctk.CTkEntry(xt, textvariable=self.var_xt, width=90).grid(row=1, column=1, sticky="w", padx=8)
-        ctk.CTkOptionMenu(xt, values=["LtoR","RtoL"], variable=self.var_dir).grid(row=1, column=2, padx=8)
-        ctk.CTkButton(xt, text="Run", command=self.on_crosstalk).grid(row=2, column=0, padx=8, pady=8, sticky="w")
+        crosstalk_card = ctk.CTkFrame(cards_container, corner_radius=12)
+        crosstalk_card.grid(row=0, column=1, sticky="nsew", padx=12, pady=12)
+        crosstalk_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(crosstalk_card, text="Crosstalk", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        fields_row = ctk.CTkFrame(crosstalk_card, fg_color="transparent")
+        fields_row.grid(row=1, column=0, sticky="ew", padx=18, pady=(0, 12))
+        fields_row.grid_columnconfigure(0, weight=1)
+        fields_row.grid_columnconfigure(1, weight=0)
+        ctk.CTkLabel(fields_row, text="Frequency (Hz)").grid(row=0, column=0, sticky="w", pady=(0, 6))
+        self.var_xt = ctk.StringVar(value="1000")
+        ctk.CTkEntry(fields_row, textvariable=self.var_xt).grid(row=1, column=0, sticky="ew", pady=(0, 6))
+        self.var_dir = ctk.StringVar(value="LtoR")
+        ctk.CTkOptionMenu(fields_row, values=["LtoR", "RtoL"], variable=self.var_dir).grid(row=1, column=1, padx=(12, 0), sticky="e")
+        ctk.CTkButton(crosstalk_card, text="Run", command=self.on_crosstalk, **self.button_style).grid(
+            row=2, column=0, sticky="e", padx=18, pady=(0, 18)
+        )
 
-        thd_card = ctk.CTkFrame(self); thd_card.grid(row=2, column=0, padx=18, pady=12, sticky="nsew")
-        ctk.CTkLabel(thd_card, text="THD (100/1k/6k Hz)").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
-        ctk.CTkButton(thd_card, text="Run", command=self.on_thd).grid(row=1, column=0, padx=8, pady=8, sticky="w")
-        iso = ctk.CTkFrame(self); iso.grid(row=2, column=1, padx=18, pady=12, sticky="nsew")
-        ctk.CTkLabel(iso, text="Isolation (Inside → Outside)").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
-        ctk.CTkButton(iso, text="Run", command=self.on_isolation).grid(row=1, column=0, padx=8, pady=8, sticky="w")
-        res = ctk.CTkFrame(self); res.grid(row=3, column=0, columnspan=2, padx=18, pady=12, sticky="nsew")
-        res.grid_rowconfigure(1, weight=1); res.grid_columnconfigure(0, weight=1)
-        ctk.CTkLabel(res, text="Experimental Results").grid(row=0, column=0, sticky="w", padx=8, pady=(8,4))
-        self.box = ctk.CTkTextbox(res); self.box.grid(row=1, column=0, sticky="nsew", padx=8, pady=8)
-        row = ctk.CTkFrame(res); row.grid(row=2, column=0, sticky="ew", padx=8, pady=(0,8))
-        ctk.CTkButton(row, text="Export LAST (JSON)", command=self.export_last).pack(side="left", padx=4)
-        ctk.CTkButton(row, text="Export ALL (JSON)", command=self.export_all).pack(side="left", padx=4)
+        thd_card = ctk.CTkFrame(cards_container, corner_radius=12)
+        thd_card.grid(row=1, column=0, sticky="nsew", padx=12, pady=12)
+        thd_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(thd_card, text="THD", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        ctk.CTkLabel(
+            thd_card,
+            text="Runs 100 / 1k / 6k Hz distortion measurements.",
+            wraplength=260,
+        ).grid(row=1, column=0, sticky="w", padx=18, pady=(0, 12))
+        ctk.CTkButton(thd_card, text="Run", command=self.on_thd, **self.button_style).grid(
+            row=2, column=0, sticky="e", padx=18, pady=(0, 18)
+        )
 
+        iso_card = ctk.CTkFrame(cards_container, corner_radius=12)
+        iso_card.grid(row=1, column=1, sticky="nsew", padx=12, pady=12)
+        iso_card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(iso_card, text="Isolation", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        ctk.CTkLabel(
+            iso_card,
+            text="Measures inside → outside isolation.",
+            wraplength=260,
+        ).grid(row=1, column=0, sticky="w", padx=18, pady=(0, 12))
+        ctk.CTkButton(iso_card, text="Run", command=self.on_isolation, **self.button_style).grid(
+            row=2, column=0, sticky="e", padx=18, pady=(0, 18)
+        )
+
+        results_frame = ctk.CTkFrame(self, corner_radius=12)
+        results_frame.grid(row=2, column=0, columnspan=2, sticky="nsew", padx=24, pady=(0, 16))
+        results_frame.grid_columnconfigure(0, weight=1)
+        results_frame.grid_rowconfigure(1, weight=1)
+        ctk.CTkLabel(results_frame, text="Experimental Results", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        self.box = ctk.CTkTextbox(results_frame)
+        self.box.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 16))
+
+        export_frame = ctk.CTkFrame(self, fg_color="transparent")
+        export_frame.grid(row=3, column=0, columnspan=2, sticky="e", padx=24, pady=(0, 24))
+        ctk.CTkButton(export_frame, text="Export LAST (JSON)", command=self.export_last, **self.button_style).grid(
+            row=0, column=0, padx=(0, 12)
+        )
+        ctk.CTkButton(export_frame, text="Export ALL (JSON)", command=self.export_all, **self.button_style).grid(row=0, column=1)
     def on_balance(self):
         r = balance.run(self.core, self.log, freq=float(self.var_bal.get()))
         self._push(r)

--- a/app/ui/pages/latency_page.py
+++ b/app/ui/pages/latency_page.py
@@ -1,94 +1,231 @@
+import datetime
+import os
 
-import os, datetime, numpy as np, customtkinter as ctk
+import customtkinter as ctk
+import numpy as np
+
 from ...tests.latency import DelayRunner, SOUND_PRESETS
 from ...core.utils import ensure_dir
 from ...config import save_config
 
+
 class LatencyPage(ctk.CTkScrollableFrame):
     def __init__(self, master, core, cfg, log_fn):
         super().__init__(master, corner_radius=0)
-        self.core = core; self.cfg = cfg; self.log = log_fn
+        self.core = core
+        self.cfg = cfg
+        self.log = log_fn
         self.runner = DelayRunner(self.cfg, self.log)
 
-        self.grid_columnconfigure(1, weight=1)
+        self.page_title_font = ctk.CTkFont(size=20, weight="bold")
+        self.section_font = ctk.CTkFont(size=14, weight="bold")
+        self.metric_font = ctk.CTkFont(size=24, weight="bold")
+        self.button_style = {"height": 36, "corner_radius": 8}
 
-        ctk.CTkLabel(self, text="Latency", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, columnspan=2, padx=18, pady=(18,4), sticky="w")
+        self.grid_columnconfigure(0, weight=1)
 
-        run_card = ctk.CTkFrame(self, corner_radius=10)
-        run_card.grid(row=1, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        run_card.grid_columnconfigure(3, weight=1)
+        ctk.CTkLabel(
+            self,
+            text="Latency",
+            font=self.page_title_font,
+        ).grid(row=0, column=0, padx=24, pady=(24, 12), sticky="w")
 
-        ctk.CTkLabel(run_card, text="Run Delay Tests").grid(row=0, column=0, padx=12, pady=(12,6), sticky="w")
+        run_frame = self._section(row=1, title="Run Delay Tests")
+        run_frame.grid_columnconfigure((0, 1, 2, 3), weight=1)
+
         self.preset_vars = {}
-        for i, p in enumerate(SOUND_PRESETS):
-            var = ctk.BooleanVar(value=(p["key"]!="impulse"))
-            self.preset_vars[p["key"]] = var
-            ctk.CTkSwitch(run_card, text=p["name"], variable=var).grid(row=1+i//3, column=i%3, padx=12, pady=6, sticky="w")
+        preset_container = ctk.CTkFrame(run_frame, fg_color="transparent")
+        preset_container.grid(row=1, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 12))
+        preset_container.grid_columnconfigure((0, 1, 2), weight=1)
+        for i, preset in enumerate(SOUND_PRESETS):
+            var = ctk.BooleanVar(value=(preset["key"] != "impulse"))
+            self.preset_vars[preset["key"]] = var
+            ctk.CTkSwitch(
+                preset_container,
+                text=preset["name"],
+                variable=var,
+            ).grid(row=i // 3, column=i % 3, padx=8, pady=6, sticky="w")
 
+        slider_row = ctk.CTkFrame(run_frame, fg_color="transparent")
+        slider_row.grid(row=2, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 12))
+        slider_row.grid_columnconfigure(1, weight=1)
+        ctk.CTkLabel(slider_row, text="Repeats").grid(row=0, column=0, sticky="w", padx=(0, 12))
         self.repeats_var = ctk.IntVar(value=self.cfg["last_settings"]["repeats"])
-        ctk.CTkLabel(run_card, text="Repeats").grid(row=3, column=0, padx=12, pady=(8,2), sticky="w")
-        self.repeats_slider = ctk.CTkSlider(run_card, from_=1, to=20, number_of_steps=19)
-        self.repeats_slider.set(self.repeats_var.get()); self.repeats_slider.grid(row=3, column=1, padx=12, pady=(8,2), sticky="ew")
-        self.repeats_label = ctk.CTkLabel(run_card, text=str(self.repeats_var.get())); self.repeats_label.grid(row=3, column=2, padx=12, pady=(8,2), sticky="w")
-        self.repeats_slider.configure(command=lambda v: self.repeats_label.configure(text=str(int(v))))
+        self.repeats_slider = ctk.CTkSlider(slider_row, from_=1, to=20, number_of_steps=19)
+        self.repeats_slider.set(self.repeats_var.get())
+        self.repeats_slider.grid(row=0, column=1, sticky="ew")
+        self.repeats_label = ctk.CTkLabel(slider_row, text=str(self.repeats_var.get()))
+        self.repeats_label.grid(row=0, column=2, sticky="e")
+        self.repeats_slider.configure(command=self._on_repeats_change)
 
-        self.save_plots_var = ctk.BooleanVar(value=True); self.save_bar_var = ctk.BooleanVar(value=True)
-        ctk.CTkSwitch(run_card, text="Save per-sound plot", variable=self.save_plots_var).grid(row=4, column=0, padx=12, pady=4, sticky="w")
-        ctk.CTkSwitch(run_card, text="Save overall bar chart", variable=self.save_bar_var).grid(row=4, column=1, padx=12, pady=4, sticky="w")
+        options_row = ctk.CTkFrame(run_frame, fg_color="transparent")
+        options_row.grid(row=3, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 12))
+        options_row.grid_columnconfigure((0, 1), weight=1)
+        self.save_plots_var = ctk.BooleanVar(value=True)
+        self.save_bar_var = ctk.BooleanVar(value=True)
+        ctk.CTkSwitch(
+            options_row,
+            text="Save per-sound plot",
+            variable=self.save_plots_var,
+        ).grid(row=0, column=0, sticky="w", pady=4)
+        ctk.CTkSwitch(
+            options_row,
+            text="Save overall bar chart",
+            variable=self.save_bar_var,
+        ).grid(row=0, column=1, sticky="w", pady=4)
 
-        ctk.CTkLabel(run_card, text="Output Folder").grid(row=5, column=0, padx=12, pady=(8,2), sticky="w")
         self.output_dir_var = ctk.StringVar(value=self.cfg["last_settings"].get("output_dir", os.getcwd()))
-        row = ctk.CTkFrame(run_card); row.grid(row=5, column=1, columnspan=2, padx=12, pady=(4,8), sticky="ew"); row.grid_columnconfigure(0, weight=1)
-        self.output_entry = ctk.CTkEntry(row, textvariable=self.output_dir_var); self.output_entry.grid(row=0, column=0, sticky="ew", padx=(0,8))
-        ctk.CTkButton(row, text="Browse", command=self._choose_outdir, width=90).grid(row=0, column=1)
+        ctk.CTkLabel(run_frame, text="Output Folder").grid(
+            row=4, column=0, sticky="w", padx=(18, 8), pady=(0, 6)
+        )
+        output_row = ctk.CTkFrame(run_frame, fg_color="transparent")
+        output_row.grid(row=4, column=1, columnspan=3, sticky="ew", padx=(0, 18), pady=(0, 12))
+        output_row.grid_columnconfigure(0, weight=1)
+        self.output_entry = ctk.CTkEntry(output_row, textvariable=self.output_dir_var)
+        self.output_entry.grid(row=0, column=0, sticky="ew", padx=(0, 8))
+        ctk.CTkButton(output_row, text="Browse", command=self._choose_outdir, width=90).grid(row=0, column=1)
 
-        btns = ctk.CTkFrame(run_card); btns.grid(row=6, column=0, columnspan=3, padx=12, pady=(0,10), sticky="ew")
-        ctk.CTkButton(btns, text="Run Selected", command=self.on_run_selected).pack(side="left", padx=6)
-        ctk.CTkButton(btns, text="Run ALL", command=self.on_run_all).pack(side="left", padx=6)
-        ctk.CTkButton(btns, text="Save Text Report", command=self.on_save_report).pack(side="right", padx=6)
+        button_row = ctk.CTkFrame(run_frame, fg_color="transparent")
+        button_row.grid(row=5, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 16))
+        button_row.grid_columnconfigure((0, 1), weight=0)
+        button_row.grid_columnconfigure(2, weight=1)
+        ctk.CTkButton(
+            button_row,
+            text="Run Selected",
+            command=self.on_run_selected,
+            **self.button_style,
+        ).grid(row=0, column=0, sticky="w")
+        ctk.CTkButton(
+            button_row,
+            text="Run ALL",
+            command=self.on_run_all,
+            **self.button_style,
+        ).grid(row=0, column=1, sticky="w", padx=12)
+        ctk.CTkButton(
+            button_row,
+            text="Save Text Report",
+            command=self.on_save_report,
+            **self.button_style,
+        ).grid(row=0, column=2, sticky="e")
 
-        kpis = ctk.CTkFrame(self); kpis.grid(row=2, column=0, columnspan=2, padx=18, pady=(0,12), sticky="ew")
-        for i in range(3): kpis.grid_columnconfigure(i, weight=1)
-        self.kpi_avg = self._kpi(kpis, "Average (ms)", "--", 0)
-        self.kpi_std = self._kpi(kpis, "Std Dev (ms)", "--", 1)
-        self.kpi_last = self._kpi(kpis, "Last (ms)", "--", 2)
+        summary_frame = self._section(row=2, title="Results Summary")
+        summary_frame.grid_columnconfigure((0, 1, 2), weight=1)
+        summary_frame.grid_rowconfigure(3, weight=1)
+        metrics_row = ctk.CTkFrame(summary_frame, fg_color="transparent")
+        metrics_row.grid(row=1, column=0, columnspan=3, sticky="ew", padx=18, pady=(0, 12))
+        metrics_row.grid_columnconfigure((0, 1, 2), weight=1)
+        self.kpi_avg = self._kpi(metrics_row, "Average (ms)", "--", 0)
+        self.kpi_std = self._kpi(metrics_row, "Std Dev (ms)", "--", 1)
+        self.kpi_last = self._kpi(metrics_row, "Last (ms)", "--", 2)
 
-        self.summary_box = ctk.CTkTextbox(self, wrap="word", height=160)
-        self.summary_box.grid(row=3, column=0, columnspan=2, padx=18, pady=(0,12), sticky="nsew")
+        ctk.CTkLabel(
+            summary_frame,
+            text="Detailed Breakdown",
+            font=ctk.CTkFont(size=12, weight="bold"),
+        ).grid(row=2, column=0, columnspan=3, sticky="w", padx=18, pady=(0, 6))
+        self.summary_box = ctk.CTkTextbox(summary_frame, wrap="word", height=160)
+        self.summary_box.grid(row=3, column=0, columnspan=3, sticky="nsew", padx=18, pady=(0, 16))
 
-        cal_card = ctk.CTkFrame(self, corner_radius=10)
-        cal_card.grid(row=4, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        ctk.CTkLabel(cal_card, text="Calibration", font=ctk.CTkFont(size=16, weight="bold")).grid(row=0, column=0, columnspan=2, padx=12, pady=(12,4), sticky="w")
+        plot_frame = self._section(row=3, title="Latency Plot")
+        plot_frame.grid_columnconfigure(0, weight=1)
+        self.plot_holder = ctk.CTkFrame(plot_frame, corner_radius=12, border_width=1, height=240)
+        self.plot_holder.grid(row=1, column=0, sticky="ew", padx=18, pady=(0, 16))
+        self.plot_holder.grid_propagate(False)
+        ctk.CTkLabel(
+            self.plot_holder,
+            text="Plots will open in a separate Matplotlib window when available.",
+            justify="left",
+            wraplength=520,
+        ).pack(fill="both", expand=True, padx=16, pady=16)
+
+        cal_frame = self._section(row=4, title="Calibration")
+        cal_frame.grid_columnconfigure((0, 1, 2), weight=1)
 
         self.cal_vars = {}
-        for i, p in enumerate(SOUND_PRESETS):
-            var = ctk.BooleanVar(value=True); self.cal_vars[p["key"]] = var
-            ctk.CTkSwitch(cal_card, text=p["name"], variable=var).grid(row=1+i//3, column=i%3, padx=12, pady=6, sticky="w")
+        cal_container = ctk.CTkFrame(cal_frame, fg_color="transparent")
+        cal_container.grid(row=1, column=0, columnspan=3, sticky="ew", padx=18, pady=(0, 12))
+        cal_container.grid_columnconfigure((0, 1, 2), weight=1)
+        for i, preset in enumerate(SOUND_PRESETS):
+            var = ctk.BooleanVar(value=True)
+            self.cal_vars[preset["key"]] = var
+            ctk.CTkSwitch(
+                cal_container,
+                text=preset["name"],
+                variable=var,
+            ).grid(row=i // 3, column=i % 3, padx=8, pady=6, sticky="w")
 
+        cal_slider_row = ctk.CTkFrame(cal_frame, fg_color="transparent")
+        cal_slider_row.grid(row=2, column=0, columnspan=3, sticky="ew", padx=18, pady=(0, 12))
+        cal_slider_row.grid_columnconfigure(1, weight=1)
+        ctk.CTkLabel(cal_slider_row, text="Repeats").grid(row=0, column=0, sticky="w", padx=(0, 12))
         self.cal_repeats_var = ctk.IntVar(value=5)
-        ctk.CTkLabel(cal_card, text="Repeats").grid(row=3, column=0, padx=12, pady=(8,2), sticky="w")
-        slider = ctk.CTkSlider(cal_card, from_=1, to=20, number_of_steps=19)
-        slider.set(self.cal_repeats_var.get()); slider.grid(row=3, column=1, padx=12, pady=(8,2), sticky="ew")
-        reps_lab = ctk.CTkLabel(cal_card, text=str(self.cal_repeats_var.get())); reps_lab.grid(row=3, column=2, padx=12, pady=(8,2), sticky="w")
-        slider.configure(command=lambda v: reps_lab.configure(text=str(int(v))))
+        cal_slider = ctk.CTkSlider(cal_slider_row, from_=1, to=20, number_of_steps=19)
+        cal_slider.set(self.cal_repeats_var.get())
+        cal_slider.grid(row=0, column=1, sticky="ew")
+        self.cal_repeats_label = ctk.CTkLabel(cal_slider_row, text=str(self.cal_repeats_var.get()))
+        self.cal_repeats_label.grid(row=0, column=2, sticky="e")
+        cal_slider.configure(command=self._on_cal_repeats_change)
 
-        btns2 = ctk.CTkFrame(cal_card); btns2.grid(row=4, column=0, columnspan=3, padx=12, pady=(0,10), sticky="ew")
-        ctk.CTkButton(btns2, text="Calibrate Selected Presets", command=self.on_cal_selected).pack(side="left", padx=6)
-        ctk.CTkButton(btns2, text="Calibrate ALL Presets", command=self.on_cal_all).pack(side="left", padx=6)
-        ctk.CTkButton(btns2, text="Calibrate GLOBAL (Impulse)", command=self.on_cal_global).pack(side="left", padx=6)
+        cal_button_row = ctk.CTkFrame(cal_frame, fg_color="transparent")
+        cal_button_row.grid(row=3, column=0, columnspan=3, sticky="ew", padx=18, pady=(0, 12))
+        cal_button_row.grid_columnconfigure((0, 1, 2), weight=1)
+        ctk.CTkButton(
+            cal_button_row,
+            text="Calibrate Selected Presets",
+            command=self.on_cal_selected,
+            **self.button_style,
+        ).grid(row=0, column=0, sticky="w")
+        ctk.CTkButton(
+            cal_button_row,
+            text="Calibrate ALL Presets",
+            command=self.on_cal_all,
+            **self.button_style,
+        ).grid(row=0, column=1, sticky="w", padx=12)
+        ctk.CTkButton(
+            cal_button_row,
+            text="Calibrate GLOBAL (Impulse)",
+            command=self.on_cal_global,
+            **self.button_style,
+        ).grid(row=0, column=2, sticky="e")
 
-        self.baseline_box = ctk.CTkTextbox(self, wrap="word", height=140)
-        self.baseline_box.grid(row=5, column=0, columnspan=2, padx=18, pady=(0,18), sticky="ew")
+        ctk.CTkLabel(
+            cal_frame,
+            text="Calibration Offsets",
+            font=ctk.CTkFont(size=12, weight="bold"),
+        ).grid(row=4, column=0, columnspan=3, sticky="w", padx=18, pady=(4, 6))
+        self.baseline_box = ctk.CTkTextbox(cal_frame, wrap="word", height=140)
+        self.baseline_box.grid(row=5, column=0, columnspan=3, sticky="ew", padx=18, pady=(0, 16))
         self._refresh_baseline_box()
 
         self.worker = None
 
-    def _kpi(self, parent, title, value, col):
-        card = ctk.CTkFrame(parent, corner_radius=10); card.grid(row=0, column=col, padx=6, sticky="ew")
-        ctk.CTkLabel(card, text=title).pack(anchor="w", padx=12, pady=(10,0))
-        val = ctk.CTkLabel(card, text=value, font=ctk.CTkFont(size=22, weight="bold"))
-        val.pack(anchor="w", padx=12, pady=(4,12)); return val
+    def _section(self, row: int, title: str) -> ctk.CTkFrame:
+        frame = ctk.CTkFrame(self)
+        frame.grid(row=row, column=0, sticky="nsew", padx=24, pady=(0, 16))
+        frame.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(frame, text=title, font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        return frame
 
+    def _on_repeats_change(self, value: float) -> None:
+        count = int(value)
+        self.repeats_var.set(count)
+        self.repeats_label.configure(text=str(count))
+
+    def _on_cal_repeats_change(self, value: float) -> None:
+        count = int(value)
+        self.cal_repeats_var.set(count)
+        self.cal_repeats_label.configure(text=str(count))
+
+    def _kpi(self, parent, title, value, col):
+        card = ctk.CTkFrame(parent, corner_radius=12)
+        card.grid(row=0, column=col, padx=8, sticky="ew")
+        card.grid_columnconfigure(0, weight=1)
+        ctk.CTkLabel(card, text=title).grid(row=0, column=0, sticky="w", padx=12, pady=(12, 4))
+        val = ctk.CTkLabel(card, text=value, font=self.metric_font)
+        val.grid(row=1, column=0, sticky="w", padx=12, pady=(0, 12))
+        return val
     def on_run_selected(self):
         presets = [p for p in SOUND_PRESETS if self.preset_vars[p["key"]].get()]
         if not presets: return

--- a/app/ui/pages/latency_page.py
+++ b/app/ui/pages/latency_page.py
@@ -126,19 +126,7 @@ class LatencyPage(ctk.CTkScrollableFrame):
         self.summary_box = ctk.CTkTextbox(summary_frame, wrap="word", height=160)
         self.summary_box.grid(row=3, column=0, columnspan=3, sticky="nsew", padx=18, pady=(0, 16))
 
-        plot_frame = self._section(row=3, title="Latency Plot")
-        plot_frame.grid_columnconfigure(0, weight=1)
-        self.plot_holder = ctk.CTkFrame(plot_frame, corner_radius=12, border_width=1, height=240)
-        self.plot_holder.grid(row=1, column=0, sticky="ew", padx=18, pady=(0, 16))
-        self.plot_holder.grid_propagate(False)
-        ctk.CTkLabel(
-            self.plot_holder,
-            text="Plots will open in a separate Matplotlib window when available.",
-            justify="left",
-            wraplength=520,
-        ).pack(fill="both", expand=True, padx=16, pady=16)
-
-        cal_frame = self._section(row=4, title="Calibration")
+        cal_frame = self._section(row=3, title="Calibration")
         cal_frame.grid_columnconfigure((0, 1, 2), weight=1)
 
         self.cal_vars = {}

--- a/app/ui/pages/results_page.py
+++ b/app/ui/pages/results_page.py
@@ -1,18 +1,38 @@
 
 import customtkinter as ctk
 
+
 class ResultsPage(ctk.CTkFrame):
     def __init__(self, master, log_sink):
         super().__init__(master, corner_radius=0)
-        self.grid_rowconfigure(1, weight=1); self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(1, weight=1)
 
-        ctk.CTkLabel(self, text="Results / Log", font=ctk.CTkFont(size=18, weight="bold")).grid(row=0, column=0, padx=18, pady=(18,4), sticky="w")
-        self.log_box = ctk.CTkTextbox(self, wrap="word"); self.log_box.grid(row=1, column=0, sticky="nsew", padx=18, pady=12)
+        self.page_title_font = ctk.CTkFont(size=20, weight="bold")
+        self.section_font = ctk.CTkFont(size=14, weight="bold")
+        self.button_style = {"height": 36, "corner_radius": 8}
+
+        ctk.CTkLabel(
+            self,
+            text="Results / Log",
+            font=self.page_title_font,
+        ).grid(row=0, column=0, padx=24, pady=(24, 12), sticky="w")
+
+        log_frame = ctk.CTkFrame(self, corner_radius=12)
+        log_frame.grid(row=1, column=0, sticky="nsew", padx=24, pady=(0, 16))
+        log_frame.grid_columnconfigure(0, weight=1)
+        log_frame.grid_rowconfigure(1, weight=1)
+        ctk.CTkLabel(log_frame, text="Results / Log", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
+        self.log_box = ctk.CTkTextbox(log_frame, wrap="word")
+        self.log_box.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 16))
         self._sink = log_sink
 
-        btns = ctk.CTkFrame(self); btns.grid(row=2, column=0, sticky="ew", padx=18, pady=(0,12))
-        ctk.CTkButton(btns, text="Copy Log", command=self.copy_log, width=110).pack(side="left", padx=6)
-        ctk.CTkButton(btns, text="Clear Log", command=self.clear_log, width=110).pack(side="left", padx=6)
+        btns = ctk.CTkFrame(self, fg_color="transparent")
+        btns.grid(row=2, column=0, sticky="e", padx=24, pady=(0, 24))
+        ctk.CTkButton(btns, text="Copy Log", command=self.copy_log, **self.button_style).grid(row=0, column=0, padx=(0, 12))
+        ctk.CTkButton(btns, text="Clear Log", command=self.clear_log, **self.button_style).grid(row=0, column=1)
 
     def append(self, msg):
         self.log_box.insert("end", msg + "\n"); self.log_box.see("end")

--- a/app/ui/pages/sweep_fr_page.py
+++ b/app/ui/pages/sweep_fr_page.py
@@ -10,6 +10,7 @@ from ...tests.sweep_fr import InputMonitorController, LevelState
 _sounddevice_spec = importlib.util.find_spec("sounddevice")
 sounddevice = importlib.import_module("sounddevice") if _sounddevice_spec else None
 
+
 class SweepFRPage(ctk.CTkFrame):
     def __init__(self, master, core, cfg, log_fn):
         super().__init__(master, corner_radius=0)
@@ -33,74 +34,125 @@ class SweepFRPage(ctk.CTkFrame):
         self.pink_noise_thread = None
         self.pink_noise_stream = None
 
-        self.grid_columnconfigure((0,1), weight=1)
+        self.page_title_font = ctk.CTkFont(size=20, weight="bold")
+        self.section_font = ctk.CTkFont(size=14, weight="bold")
+        self.button_style = {"height": 36, "corner_radius": 8}
+
+        self.grid_columnconfigure((0, 1), weight=1)
         self.grid_rowconfigure(2, weight=1)
 
-        # Title
         ctk.CTkLabel(
-            self, text="Sweep Frequency Response",
-            font=ctk.CTkFont(size=18, weight="bold")
-        ).grid(row=0, column=0, columnspan=2, padx=18, pady=(18, 4), sticky="w")
+            self,
+            text="Sweep Frequency Response",
+            font=self.page_title_font,
+        ).grid(row=0, column=0, columnspan=2, padx=24, pady=(24, 12), sticky="w")
 
-        # Sweep configuration card (unchanged)
-        run_card = ctk.CTkFrame(self)
-        run_card.grid(row=1, column=0, columnspan=2, padx=18, pady=12, sticky="ew")
-        run_card.grid_columnconfigure(3, weight=1)
+        settings = ctk.CTkFrame(self)
+        settings.grid(row=1, column=0, columnspan=2, sticky="ew", padx=24, pady=(12, 16))
+        settings.grid_columnconfigure((1, 3, 5, 7), weight=1)
+        ctk.CTkLabel(settings, text="Sweep Settings", font=self.section_font).grid(
+            row=0, column=0, columnspan=8, sticky="w", padx=18, pady=(16, 10)
+        )
 
         self.var_f0 = ctk.StringVar(value="20")
         self.var_f1 = ctk.StringVar(value="20000")
         self.var_dur = ctk.StringVar(value="6.0")
         self.var_rep = ctk.IntVar(value=1)
 
-        ctk.CTkLabel(run_card, text="Start Freq (Hz)").grid(row=0, column=0, sticky="w", padx=8, pady=(8, 4))
-        ctk.CTkEntry(run_card, textvariable=self.var_f0, width=90).grid(row=0, column=1, sticky="w", padx=8, pady=(8, 4))
-        ctk.CTkLabel(run_card, text="End Freq (Hz)").grid(row=0, column=2, sticky="w", padx=8, pady=(8, 4))
-        ctk.CTkEntry(run_card, textvariable=self.var_f1, width=90).grid(row=0, column=3, sticky="w", padx=8, pady=(8, 4))
+        ctk.CTkLabel(settings, text="Start Freq (Hz)").grid(
+            row=1, column=0, sticky="w", padx=(18, 8), pady=(0, 6)
+        )
+        ctk.CTkEntry(settings, textvariable=self.var_f0).grid(
+            row=1, column=1, sticky="ew", padx=(0, 18), pady=(0, 6)
+        )
 
-        ctk.CTkLabel(run_card, text="Duration (s)").grid(row=1, column=0, sticky="w", padx=8)
-        ctk.CTkEntry(run_card, textvariable=self.var_dur, width=90).grid(row=1, column=1, sticky="w", padx=8)
+        ctk.CTkLabel(settings, text="End Freq (Hz)").grid(
+            row=1, column=2, sticky="w", padx=(18, 8), pady=(0, 6)
+        )
+        ctk.CTkEntry(settings, textvariable=self.var_f1).grid(
+            row=1, column=3, sticky="ew", padx=(0, 18), pady=(0, 6)
+        )
 
-        ctk.CTkLabel(run_card, text="Repeats").grid(row=2, column=0, sticky="w", padx=8)
-        rep_slider = ctk.CTkSlider(run_card, from_=1, to=20, number_of_steps=19)
-        rep_slider.set(self.var_rep.get())
-        rep_slider.grid(row=2, column=1, sticky="ew", padx=8)
-        rep_lab = ctk.CTkLabel(run_card, text=str(self.var_rep.get()))
-        rep_lab.grid(row=2, column=2, padx=8, sticky="w")
-        rep_slider.configure(command=lambda v: (self.var_rep.set(int(v)), rep_lab.configure(text=str(int(v)))))
+        ctk.CTkLabel(settings, text="Duration (s)").grid(
+            row=1, column=4, sticky="w", padx=(18, 8), pady=(0, 6)
+        )
+        ctk.CTkEntry(settings, textvariable=self.var_dur).grid(
+            row=1, column=5, sticky="ew", padx=(0, 18), pady=(0, 6)
+        )
 
+        ctk.CTkLabel(settings, text="Repeats").grid(
+            row=1, column=6, sticky="w", padx=(18, 8), pady=(0, 6)
+        )
+        repeats_cell = ctk.CTkFrame(settings, fg_color="transparent")
+        repeats_cell.grid(row=1, column=7, sticky="ew", padx=(0, 18), pady=(0, 6))
+        repeats_cell.grid_columnconfigure(0, weight=1)
+        self.rep_slider = ctk.CTkSlider(repeats_cell, from_=1, to=20, number_of_steps=19)
+        self.rep_slider.set(self.var_rep.get())
+        self.rep_slider.grid(row=0, column=0, sticky="ew")
+        self.rep_label = ctk.CTkLabel(repeats_cell, text=str(self.var_rep.get()))
+        self.rep_label.grid(row=0, column=1, sticky="e", padx=(8, 0))
+        self.rep_slider.configure(command=self._on_repeat_slider)
+
+        options_row = ctk.CTkFrame(settings, fg_color="transparent")
+        options_row.grid(row=2, column=0, columnspan=8, sticky="ew", padx=18, pady=(6, 12))
+        options_row.grid_columnconfigure((0, 1, 2), weight=1)
         self.save_plots_var = ctk.BooleanVar(value=True)
-        ctk.CTkSwitch(run_card, text="Save plots", variable=self.save_plots_var).grid(
-            row=3, column=0, padx=8, pady=(8, 4), sticky="w"
-        )
-
         self.save_squiglink_var = ctk.BooleanVar(value=True)
-        ctk.CTkSwitch(run_card, text="Save Squiglink format (.txt)", variable=self.save_squiglink_var).grid(
-            row=3, column=1, columnspan=2, padx=8, pady=(8, 4), sticky="w"
-        )
-
-        # Mono mode switch (only affects sweep_fr)
         self.mono_mode_var = ctk.BooleanVar(value=False)
-        ctk.CTkSwitch(run_card, text="Mono Test (one side at a time)", variable=self.mono_mode_var).grid(
-            row=3, column=3, padx=8, pady=(8, 4), sticky="w"
+        ctk.CTkSwitch(options_row, text="Save plots", variable=self.save_plots_var).grid(
+            row=0, column=0, sticky="w", pady=4
+        )
+        ctk.CTkSwitch(
+            options_row,
+            text="Save Squiglink format (.txt)",
+            variable=self.save_squiglink_var,
+        ).grid(row=0, column=1, sticky="w", pady=4)
+        ctk.CTkSwitch(
+            options_row,
+            text="Mono Test (one side at a time)",
+            variable=self.mono_mode_var,
+        ).grid(row=0, column=2, sticky="w", pady=4)
+
+        ctk.CTkLabel(settings, text="Output Folder").grid(
+            row=3, column=0, sticky="w", padx=(18, 8), pady=(0, 6)
+        )
+        self.output_dir_var = ctk.StringVar(value=self.cfg["last_settings"].get("output_dir", os.getcwd()))
+        output_row = ctk.CTkFrame(settings, fg_color="transparent")
+        output_row.grid(row=3, column=1, columnspan=6, sticky="ew", padx=(0, 18), pady=(0, 12))
+        output_row.grid_columnconfigure(0, weight=1)
+        self.output_entry = ctk.CTkEntry(output_row, textvariable=self.output_dir_var)
+        self.output_entry.grid(row=0, column=0, sticky="ew", padx=(0, 8))
+        ctk.CTkButton(output_row, text="Browse", command=self._choose_outdir, width=90).grid(row=0, column=1)
+        ctk.CTkButton(settings, text="Run Sweep", command=self.on_run, **self.button_style).grid(
+            row=3, column=7, sticky="e", padx=(0, 18), pady=(0, 12)
         )
 
-        ctk.CTkLabel(run_card, text="Output Folder").grid(row=4, column=0, padx=8, pady=(8, 2), sticky="w")
-        self.output_dir_var = ctk.StringVar(value=self.cfg["last_settings"].get("output_dir", os.getcwd()))
-        row = ctk.CTkFrame(run_card)
-        row.grid(row=4, column=1, columnspan=3, padx=8, pady=(4, 8), sticky="ew")
-        row.grid_columnconfigure(0, weight=1)
-        self.output_entry = ctk.CTkEntry(row, textvariable=self.output_dir_var)
-        self.output_entry.grid(row=0, column=0, sticky="ew", padx=(0, 8))
-        ctk.CTkButton(row, text="Browse", command=self._choose_outdir, width=90).grid(row=0, column=1)
+        self.monitor_card = self._build_level_monitor()
+        self.monitor_card.grid(row=2, column=0, sticky="nsew", padx=24, pady=(0, 16))
+        self.results_card = self._build_results()
+        self.results_card.grid(row=2, column=1, sticky="nsew", padx=24, pady=(0, 16))
 
-        # Run Sweep button inside config card
-        ctk.CTkButton(run_card, text="Run Sweep", command=self.on_run).grid(row=5, column=0, padx=8, pady=(4, 8), sticky="w")
-
-        # Bottom area split into 2 columns
-        self._build_level_monitor().grid(row=2, column=0, padx=18, pady=12, sticky="nsew")
-        self._build_results().grid(row=2, column=1, padx=18, pady=12, sticky="nsew")
+        export_frame = ctk.CTkFrame(self, fg_color="transparent")
+        export_frame.grid(row=3, column=0, columnspan=2, sticky="e", padx=24, pady=(0, 24))
+        ctk.CTkButton(export_frame, text="Export LAST (JSON)", command=self.export_last, **self.button_style).grid(
+            row=0, column=0, padx=(0, 12)
+        )
+        ctk.CTkButton(export_frame, text="Export ALL (JSON)", command=self.export_all, **self.button_style).grid(
+            row=0, column=1, padx=12
+        )
+        ctk.CTkButton(
+            export_frame,
+            text="Export LAST to Squiglink",
+            command=self.export_last_squiglink,
+            **self.button_style,
+        ).grid(row=0, column=2)
 
         self.after(100, self._update_meter_display)
+
+    def _on_repeat_slider(self, value: float) -> None:
+        count = int(value)
+        self.var_rep.set(count)
+        self.rep_label.configure(text=str(count))
 
     def _choose_outdir(self):
         from tkinter import filedialog
@@ -109,24 +161,24 @@ class SweepFRPage(ctk.CTkFrame):
             self.output_dir_var.set(d)
 
     def _build_level_monitor(self):
-        level_card = ctk.CTkFrame(self, corner_radius=10)
-        level_card.grid_columnconfigure(1, weight=1)
+        level_card = ctk.CTkFrame(self, corner_radius=12)
+        level_card.grid_columnconfigure(0, weight=1)
 
-        ctk.CTkLabel(level_card, text="Input Level Monitor", font=ctk.CTkFont(size=14, weight="bold")).grid(
-            row=0, column=0, columnspan=3, padx=12, pady=(12, 4), sticky="w"
+        ctk.CTkLabel(level_card, text="Input Level Monitor", font=self.section_font).grid(
+            row=0, column=0, columnspan=4, sticky="w", padx=18, pady=(16, 10)
         )
         self.status_label = ctk.CTkLabel(level_card, text="Ready to measure...", font=ctk.CTkFont(size=12))
-        self.status_label.grid(row=1, column=0, columnspan=3, padx=12, pady=4, sticky="w")
+        self.status_label.grid(row=1, column=0, columnspan=4, sticky="w", padx=18, pady=(0, 8))
 
-        meter_frame = ctk.CTkFrame(level_card, height=80)
-        meter_frame.grid(row=2, column=0, columnspan=3, padx=12, pady=8, sticky="ew")
+        meter_frame = ctk.CTkFrame(level_card, corner_radius=12, height=110)
+        meter_frame.grid(row=2, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 12))
         meter_frame.grid_columnconfigure(0, weight=1)
         meter_frame.grid_propagate(False)
-        self.level_canvas = ctk.CTkCanvas(meter_frame, height=60, bg="#2b2b2b", highlightthickness=0)
-        self.level_canvas.grid(row=0, column=0, sticky="ew", padx=8, pady=8)
+        self.level_canvas = ctk.CTkCanvas(meter_frame, height=70, bg="#1f1f22", highlightthickness=0)
+        self.level_canvas.grid(row=0, column=0, sticky="ew", padx=12, pady=12)
 
-        readout_frame = ctk.CTkFrame(level_card)
-        readout_frame.grid(row=3, column=0, columnspan=3, padx=12, pady=(0, 8), sticky="ew")
+        readout_frame = ctk.CTkFrame(level_card, fg_color="transparent")
+        readout_frame.grid(row=3, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 12))
         readout_frame.grid_columnconfigure((0, 1, 2), weight=1)
         ctk.CTkLabel(readout_frame, text="Current Level:").grid(row=0, column=0, padx=8, pady=4, sticky="w")
         self.current_level_label = ctk.CTkLabel(readout_frame, text="-- dBFS", font=ctk.CTkFont(size=16, weight="bold"))
@@ -138,33 +190,52 @@ class SweepFRPage(ctk.CTkFrame):
         self.spl_label = ctk.CTkLabel(readout_frame, text="-- dB SPL", font=ctk.CTkFont(size=16, weight="bold"))
         self.spl_label.grid(row=1, column=2, padx=8, pady=4, sticky="e")
 
-        control_frame = ctk.CTkFrame(level_card)
-        control_frame.grid(row=4, column=0, columnspan=3, padx=12, pady=(0, 12), sticky="ew")
-        self.monitor_button = ctk.CTkButton(control_frame, text="Start Monitoring", command=self.toggle_monitoring, width=140)
-        self.monitor_button.pack(side="left", padx=6)
-        self.pink_noise_button = ctk.CTkButton(control_frame, text="Play Pink Noise", command=self.toggle_pink_noise, width=140)
-        self.pink_noise_button.pack(side="left", padx=6)
+        control_frame = ctk.CTkFrame(level_card, fg_color="transparent")
+        control_frame.grid(row=4, column=0, columnspan=4, sticky="ew", padx=18, pady=(0, 18))
+        control_frame.grid_columnconfigure((0, 1, 2), weight=0)
+        control_frame.grid_columnconfigure(3, weight=1)
+        self.monitor_button = ctk.CTkButton(
+            control_frame,
+            text="Start Monitoring",
+            command=self.toggle_monitoring,
+            **self.button_style,
+        )
+        self.monitor_button.grid(row=0, column=0, padx=(0, 12))
+        self.pink_noise_button = ctk.CTkButton(
+            control_frame,
+            text="Play Pink Noise",
+            command=self.toggle_pink_noise,
+            **self.button_style,
+        )
+        self.pink_noise_button.grid(row=0, column=1, padx=12)
         if sounddevice is None:
             self.pink_noise_button.configure(state="disabled")
-        self.reset_peak_button = ctk.CTkButton(control_frame, text="Reset Peak", command=self.reset_peak, width=100)
-        self.reset_peak_button.pack(side="left", padx=6)
-        self.clip_warning = ctk.CTkLabel(control_frame, text="", text_color="red", font=ctk.CTkFont(size=12, weight="bold"))
-        self.clip_warning.pack(side="right", padx=12)
+        self.reset_peak_button = ctk.CTkButton(
+            control_frame,
+            text="Reset Peak",
+            command=self.reset_peak,
+            **self.button_style,
+        )
+        self.reset_peak_button.grid(row=0, column=2, padx=12)
+        self.clip_warning = ctk.CTkLabel(
+            control_frame,
+            text="",
+            text_color="red",
+            font=ctk.CTkFont(size=12, weight="bold"),
+        )
+        self.clip_warning.grid(row=0, column=3, sticky="e")
 
         return level_card
 
     def _build_results(self):
-        res = ctk.CTkFrame(self)
+        res = ctk.CTkFrame(self, corner_radius=12)
         res.grid_rowconfigure(1, weight=1)
         res.grid_columnconfigure(0, weight=1)
-        ctk.CTkLabel(res, text="Sweep FR Results").grid(row=0, column=0, sticky="w", padx=8, pady=(8, 4))
+        ctk.CTkLabel(res, text="Sweep FR Results", font=self.section_font).grid(
+            row=0, column=0, sticky="w", padx=18, pady=(16, 10)
+        )
         self.box = ctk.CTkTextbox(res)
-        self.box.grid(row=1, column=0, sticky="nsew", padx=8, pady=8)
-        row2 = ctk.CTkFrame(res)
-        row2.grid(row=2, column=0, sticky="ew", padx=8, pady=(0, 8))
-        ctk.CTkButton(row2, text="Export LAST (JSON)", command=self.export_last).pack(side="left", padx=4)
-        ctk.CTkButton(row2, text="Export ALL (JSON)", command=self.export_all).pack(side="left", padx=4)
-        ctk.CTkButton(row2, text="Export LAST to Squiglink", command=self.export_last_squiglink).pack(side="left", padx=4)
+        self.box.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 16))
         return res
 
     def on_run(self):

--- a/app/ui/pages/sweep_fr_page.py
+++ b/app/ui/pages/sweep_fr_page.py
@@ -130,22 +130,7 @@ class SweepFRPage(ctk.CTkFrame):
         self.monitor_card = self._build_level_monitor()
         self.monitor_card.grid(row=2, column=0, sticky="nsew", padx=24, pady=(0, 16))
         self.results_card = self._build_results()
-        self.results_card.grid(row=2, column=1, sticky="nsew", padx=24, pady=(0, 16))
-
-        export_frame = ctk.CTkFrame(self, fg_color="transparent")
-        export_frame.grid(row=3, column=0, columnspan=2, sticky="e", padx=24, pady=(0, 24))
-        ctk.CTkButton(export_frame, text="Export LAST (JSON)", command=self.export_last, **self.button_style).grid(
-            row=0, column=0, padx=(0, 12)
-        )
-        ctk.CTkButton(export_frame, text="Export ALL (JSON)", command=self.export_all, **self.button_style).grid(
-            row=0, column=1, padx=12
-        )
-        ctk.CTkButton(
-            export_frame,
-            text="Export LAST to Squiglink",
-            command=self.export_last_squiglink,
-            **self.button_style,
-        ).grid(row=0, column=2)
+        self.results_card.grid(row=2, column=1, sticky="nsew", padx=24, pady=(0, 24))
 
         self.after(100, self._update_meter_display)
 
@@ -235,7 +220,29 @@ class SweepFRPage(ctk.CTkFrame):
             row=0, column=0, sticky="w", padx=18, pady=(16, 10)
         )
         self.box = ctk.CTkTextbox(res)
-        self.box.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 16))
+        self.box.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 12))
+
+        button_row = ctk.CTkFrame(res, fg_color="transparent")
+        button_row.grid(row=2, column=0, sticky="ew", padx=18, pady=(0, 18))
+        button_row.grid_columnconfigure(0, weight=1)
+        ctk.CTkButton(
+            button_row,
+            text="Export LAST (JSON)",
+            command=self.export_last,
+            **self.button_style,
+        ).grid(row=0, column=1, padx=(0, 12))
+        ctk.CTkButton(
+            button_row,
+            text="Export ALL (JSON)",
+            command=self.export_all,
+            **self.button_style,
+        ).grid(row=0, column=2, padx=12)
+        ctk.CTkButton(
+            button_row,
+            text="Export LAST to Squiglink",
+            command=self.export_last_squiglink,
+            **self.button_style,
+        ).grid(row=0, column=3)
         return res
 
     def on_run(self):

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -1,6 +1,104 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict
 
 import customtkinter as ctk
 
-def apply_theme(cfg_ui):
-    ctk.set_appearance_mode(cfg_ui.get("appearance_mode", "Dark"))
-    ctk.set_default_color_theme(cfg_ui.get("color_theme", "blue"))
+THEME_DIR = Path(__file__).resolve().parent / "themes"
+CONFIG_PATH = Path.home() / ".pawdiolab" / "theme.json"
+
+ACCENT_FILES: Dict[str, Path] = {
+    "greyscale": THEME_DIR / "greyscale.json",
+    "blue": THEME_DIR / "blue.json",
+    "teal": THEME_DIR / "teal.json",
+    "purple": THEME_DIR / "purple.json",
+}
+
+
+@dataclass
+class ThemeConfig:
+    appearance_mode: str = "Dark"
+    accent: str = "greyscale"
+
+
+DEFAULT_THEME = ThemeConfig()
+
+
+def _normalise_appearance(value: str | None) -> str:
+    if not value:
+        return DEFAULT_THEME.appearance_mode
+    value = value.strip().lower()
+    if value == "light":
+        return "Light"
+    if value == "system":
+        return "System"
+    return "Dark"
+
+
+def _normalise_accent(value: str | None) -> str:
+    if not value:
+        return DEFAULT_THEME.accent
+    key = value.strip().lower()
+    return key if key in ACCENT_FILES else DEFAULT_THEME.accent
+
+
+def load_theme_config(path: Path | None = None) -> ThemeConfig:
+    """Load the persisted theme configuration."""
+
+    cfg_path = Path(path) if path else CONFIG_PATH
+    try:
+        with cfg_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return ThemeConfig()
+    except Exception:
+        return ThemeConfig()
+
+    appearance = _normalise_appearance(data.get("appearance_mode"))
+    accent = _normalise_accent(data.get("accent") or data.get("color_theme"))
+    return ThemeConfig(appearance_mode=appearance, accent=accent)
+
+
+def save_theme_config(theme: ThemeConfig, path: Path | None = None) -> None:
+    cfg_path = Path(path) if path else CONFIG_PATH
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    with cfg_path.open("w", encoding="utf-8") as fh:
+        json.dump(asdict(theme), fh, indent=2)
+
+
+def apply_theme(theme: ThemeConfig) -> None:
+    """Apply theme values to CustomTkinter."""
+
+    appearance = _normalise_appearance(theme.appearance_mode)
+    accent = _normalise_accent(theme.accent)
+
+    accent_file = ACCENT_FILES.get(accent)
+    if accent_file and accent_file.exists():
+        ctk.set_default_color_theme(str(accent_file))
+    else:
+        ctk.set_default_color_theme("dark-blue")
+
+    ctk.set_appearance_mode(appearance)
+
+
+def available_accents() -> Dict[str, str]:
+    """Return machine -> human readable accent names."""
+
+    return {
+        "greyscale": "Greyscale (default)",
+        "blue": "Blue",
+        "teal": "Teal",
+        "purple": "Purple",
+    }
+
+
+def theme_from_legacy(ui_config: dict | None) -> ThemeConfig:
+    """Translate older config dictionaries into ThemeConfig."""
+
+    ui_config = ui_config or {}
+    appearance = _normalise_appearance(ui_config.get("appearance_mode"))
+    accent = _normalise_accent(ui_config.get("accent") or ui_config.get("color_theme"))
+    return ThemeConfig(appearance_mode=appearance, accent=accent)

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -5,6 +5,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict
 
+import tkinter as tk
+
 import customtkinter as ctk
 
 THEME_DIR = Path(__file__).resolve().parent / "themes"
@@ -69,7 +71,7 @@ def save_theme_config(theme: ThemeConfig, path: Path | None = None) -> None:
         json.dump(asdict(theme), fh, indent=2)
 
 
-def apply_theme(theme: ThemeConfig) -> None:
+def apply_theme(theme: ThemeConfig, root: tk.Misc | None = None) -> None:
     """Apply theme values to CustomTkinter."""
 
     appearance = _normalise_appearance(theme.appearance_mode)
@@ -82,6 +84,37 @@ def apply_theme(theme: ThemeConfig) -> None:
         ctk.set_default_color_theme("dark-blue")
 
     ctk.set_appearance_mode(appearance)
+
+    if root is not None:
+        _refresh_widget_tree(root)
+
+
+def _refresh_widget_tree(widget: tk.Misc) -> None:
+    """Recursively refresh widget colors from the active theme."""
+
+    if not hasattr(widget, "configure"):
+        return
+
+    theme_key = widget.__class__.__name__
+    theme_values = ctk.ThemeManager.theme.get(theme_key, {})
+    for option, value in theme_values.items():
+        if option in {"macOS", "Windows", "Linux"}:
+            continue
+        if "color" not in option:
+            continue
+        try:
+            widget.configure(**{option: value})
+        except (tk.TclError, AttributeError, TypeError):
+            continue
+
+    # CTkScrollableFrame nests content inside ``scrollable_frame``
+    child_containers = list(widget.winfo_children())
+    if hasattr(widget, "scrollable_frame"):
+        child_containers.append(widget.scrollable_frame)
+
+    for child in child_containers:
+        if isinstance(child, tk.Misc):
+            _refresh_widget_tree(child)
 
 
 def available_accents() -> Dict[str, str]:

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -95,12 +95,16 @@ def _refresh_widget_tree(widget: tk.Misc) -> None:
     if not hasattr(widget, "configure"):
         return
 
+    supported_options = _configurable_options(widget)
+
     theme_key = widget.__class__.__name__
     theme_values = ctk.ThemeManager.theme.get(theme_key, {})
     for option, value in theme_values.items():
         if option in {"macOS", "Windows", "Linux"}:
             continue
         if "color" not in option:
+            continue
+        if option not in supported_options:
             continue
         try:
             widget.configure(**{option: value})
@@ -115,6 +119,27 @@ def _refresh_widget_tree(widget: tk.Misc) -> None:
     for child in child_containers:
         if isinstance(child, tk.Misc):
             _refresh_widget_tree(child)
+
+
+def _configurable_options(widget: tk.Misc) -> set[str]:
+    """Return the configuration option names accepted by the widget."""
+
+    try:
+        config = widget.configure()
+    except Exception:  # pragma: no cover - defensive guard
+        return set()
+
+    if isinstance(config, dict):
+        return set(config.keys())
+
+    options: set[str] = set()
+    if isinstance(config, (tuple, list)):
+        for item in config:
+            if isinstance(item, (tuple, list)) and item:
+                key = item[0]
+                if isinstance(key, str):
+                    options.add(key)
+    return options
 
 
 def available_accents() -> Dict[str, str]:

--- a/app/ui/themes/blue.json
+++ b/app/ui/themes/blue.json
@@ -1,0 +1,155 @@
+{
+  "CTk": {
+    "fg_color": ["#f0f3f8", "#11141b"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["#f0f3f8", "#11141b"]
+  },
+  "CTkFrame": {
+    "corner_radius": 12,
+    "border_width": 1,
+    "fg_color": ["#f8f9fb", "#1a1d26"],
+    "top_fg_color": ["#e6eaf1", "#1f232d"],
+    "border_color": ["#c4cbda", "#27303d"]
+  },
+  "CTkButton": {
+    "corner_radius": 8,
+    "border_width": 0,
+    "fg_color": ["#5b87f2", "#3c5fb8"],
+    "hover_color": ["#4c74d6", "#324f9b"],
+    "border_color": ["#6d96f5", "#4869c4"],
+    "text_color": ["#ffffff", "#f6f7fb"],
+    "text_color_disabled": ["#a9b3c6", "#4f5668"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "fg_color": "transparent",
+    "text_color": ["#131721", "#f6f7fb"]
+  },
+  "CTkEntry": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#ffffff", "#1f232d"],
+    "border_color": ["#c4cbda", "#30394a"],
+    "text_color": ["#131721", "#f0f2f8"],
+    "placeholder_text_color": ["#7a869c", "#67718a"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 10,
+    "border_width": 3,
+    "fg_color": ["#5b87f2", "#3c5fb8"],
+    "border_color": ["#6d96f5", "#4869c4"],
+    "hover_color": ["#4c74d6", "#324f9b"],
+    "checkmark_color": ["#f6f7fb", "#f6f7fb"],
+    "text_color": ["#131721", "#f6f7fb"],
+    "text_color_disabled": ["#95a0b5", "#4f5668"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#c5ccda", "#343b49"],
+    "progress_color": ["#5b87f2", "#3c5fb8"],
+    "button_color": ["#ffffff", "#90a6e6"],
+    "button_hover_color": ["#e4e8f5", "#a6b9f0"],
+    "text_color": ["#131721", "#f6f7fb"],
+    "text_color_disabled": ["#9da9bf", "#4f5668"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#5b87f2", "#3c5fb8"],
+    "border_color": ["#6d96f5", "#4869c4"],
+    "hover_color": ["#4c74d6", "#324f9b"],
+    "text_color": ["#131721", "#f6f7fb"],
+    "text_color_disabled": ["#95a0b5", "#4f5668"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#d2d8e6", "#303746"],
+    "progress_color": ["#5b87f2", "#3c5fb8"],
+    "border_color": ["#d2d8e6", "#303746"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#d2d8e6", "#303746"],
+    "progress_color": ["#5b87f2", "#3c5fb8"],
+    "button_color": ["#4c74d6", "#324f9b"],
+    "button_hover_color": ["#3f63b8", "#2a3f7d"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 8,
+    "fg_color": ["#5b87f2", "#3c5fb8"],
+    "button_color": ["#4c74d6", "#324f9b"],
+    "button_hover_color": ["#3f63b8", "#2a3f7d"],
+    "text_color": ["#ffffff", "#f6f7fb"],
+    "text_color_disabled": ["#a9b3c6", "#4f5668"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#ffffff", "#1f232d"],
+    "border_color": ["#c4cbda", "#30394a"],
+    "button_color": ["#6d96f5", "#4869c4"],
+    "button_hover_color": ["#4c74d6", "#324f9b"],
+    "text_color": ["#131721", "#f0f2f8"],
+    "text_color_disabled": ["#9da9bf", "#4f5668"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["#c4cbda", "#3a4252"],
+    "button_hover_color": ["#adb7cc", "#4a5261"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#c4cbda", "#2b3240"],
+    "selected_color": ["#5b87f2", "#3c5fb8"],
+    "selected_hover_color": ["#4c74d6", "#324f9b"],
+    "unselected_color": ["#dbe2f4", "#343b49"],
+    "unselected_hover_color": ["#c9d1e6", "#40485a"],
+    "text_color": ["#ffffff", "#f6f7fb"],
+    "text_color_disabled": ["#a9b3c6", "#4f5668"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 8,
+    "border_width": 1,
+    "fg_color": ["#ffffff", "#191c24"],
+    "border_color": ["#c4cbda", "#2c3442"],
+    "text_color": ["#131721", "#f0f2f8"],
+    "scrollbar_button_color": ["#c4cbda", "#3a4252"],
+    "scrollbar_button_hover_color": ["#adb7cc", "#4a5261"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["#e6eaf1", "#171b23"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["#e9edf7", "#202633"],
+    "hover_color": ["#d6dff5", "#283041"],
+    "text_color": ["#131721", "#f6f7fb"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Pro Display",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Segoe UI",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Inter",
+      "size": 12,
+      "weight": "normal"
+    }
+  }
+}

--- a/app/ui/themes/greyscale.json
+++ b/app/ui/themes/greyscale.json
@@ -1,0 +1,155 @@
+{
+  "CTk": {
+    "fg_color": ["#f1f2f4", "#151619"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["#f1f2f4", "#151619"]
+  },
+  "CTkFrame": {
+    "corner_radius": 12,
+    "border_width": 1,
+    "fg_color": ["#fafbfc", "#1d1f22"],
+    "top_fg_color": ["#eef1f4", "#22252a"],
+    "border_color": ["#d5d8dc", "#2e3237"]
+  },
+  "CTkButton": {
+    "corner_radius": 8,
+    "border_width": 0,
+    "fg_color": ["#b5b9bf", "#4b4f54"],
+    "hover_color": ["#a7abb2", "#414549"],
+    "border_color": ["#c3c7cd", "#5a5e63"],
+    "text_color": ["#1f2124", "#f4f5f7"],
+    "text_color_disabled": ["#aeb2b7", "#5c6064"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "fg_color": "transparent",
+    "text_color": ["#1c1e21", "#f5f6f7"]
+  },
+  "CTkEntry": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#fcfcfd", "#25272b"],
+    "border_color": ["#c9cdd2", "#3a3e43"],
+    "text_color": ["#1c1e21", "#f1f2f4"],
+    "placeholder_text_color": ["#7a7f85", "#6b6f74"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 10,
+    "border_width": 3,
+    "fg_color": ["#b5b9bf", "#4b4f54"],
+    "border_color": ["#c3c7cd", "#5a5e63"],
+    "hover_color": ["#a7abb2", "#414549"],
+    "checkmark_color": ["#f4f5f7", "#f4f5f7"],
+    "text_color": ["#1c1e21", "#f5f6f7"],
+    "text_color_disabled": ["#9da1a6", "#5c6064"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#c5c8cd", "#3a3d42"],
+    "progress_color": ["#b5b9bf", "#4b4f54"],
+    "button_color": ["#f7f8f9", "#bfc3c8"],
+    "button_hover_color": ["#e8eaed", "#d4d7db"],
+    "text_color": ["#1c1e21", "#f5f6f7"],
+    "text_color_disabled": ["#a5a9ae", "#5c6064"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#b5b9bf", "#4b4f54"],
+    "border_color": ["#c3c7cd", "#5a5e63"],
+    "hover_color": ["#a7abb2", "#414549"],
+    "text_color": ["#1c1e21", "#f5f6f7"],
+    "text_color_disabled": ["#9da1a6", "#5c6064"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#d7dade", "#36393e"],
+    "progress_color": ["#b5b9bf", "#4b4f54"],
+    "border_color": ["#d7dade", "#36393e"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#d7dade", "#36393e"],
+    "progress_color": ["#b5b9bf", "#4b4f54"],
+    "button_color": ["#8f9499", "#5f6367"],
+    "button_hover_color": ["#7e8287", "#4f5357"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 8,
+    "fg_color": ["#b5b9bf", "#4b4f54"],
+    "button_color": ["#a7abb2", "#414549"],
+    "button_hover_color": ["#9b9fa5", "#383c40"],
+    "text_color": ["#1f2124", "#f4f5f7"],
+    "text_color_disabled": ["#aeb2b7", "#5c6064"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#fcfcfd", "#25272b"],
+    "border_color": ["#c9cdd2", "#3a3e43"],
+    "button_color": ["#c3c7cd", "#5a5e63"],
+    "button_hover_color": ["#adb1b7", "#4d5156"],
+    "text_color": ["#1c1e21", "#f1f2f4"],
+    "text_color_disabled": ["#a0a4a9", "#5c6064"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["#c3c7cd", "#3f4247"],
+    "button_hover_color": ["#adb1b7", "#505459"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#c9cdd2", "#303338"],
+    "selected_color": ["#b5b9bf", "#4b4f54"],
+    "selected_hover_color": ["#a7abb2", "#414549"],
+    "unselected_color": ["#d7dade", "#373a3f"],
+    "unselected_hover_color": ["#c3c7cd", "#464a4f"],
+    "text_color": ["#1f2124", "#f4f5f7"],
+    "text_color_disabled": ["#aeb2b7", "#5c6064"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 8,
+    "border_width": 1,
+    "fg_color": ["#ffffff", "#202226"],
+    "border_color": ["#c9cdd2", "#3a3e43"],
+    "text_color": ["#1c1e21", "#f1f2f4"],
+    "scrollbar_button_color": ["#c3c7cd", "#3f4247"],
+    "scrollbar_button_hover_color": ["#adb1b7", "#505459"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["#eef1f4", "#1b1d20"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["#f4f5f7", "#232529"],
+    "hover_color": ["#e0e2e5", "#2e3236"],
+    "text_color": ["#1c1e21", "#f5f6f7"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Pro Display",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Segoe UI",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Inter",
+      "size": 12,
+      "weight": "normal"
+    }
+  }
+}

--- a/app/ui/themes/purple.json
+++ b/app/ui/themes/purple.json
@@ -1,0 +1,155 @@
+{
+  "CTk": {
+    "fg_color": ["#f4f1fb", "#141019"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["#f4f1fb", "#141019"]
+  },
+  "CTkFrame": {
+    "corner_radius": 12,
+    "border_width": 1,
+    "fg_color": ["#fbf9ff", "#1b1624"],
+    "top_fg_color": ["#ebe4ff", "#211c2d"],
+    "border_color": ["#d4c9f0", "#2b2439"]
+  },
+  "CTkButton": {
+    "corner_radius": 8,
+    "border_width": 0,
+    "fg_color": ["#8264f6", "#5a3fd6"],
+    "hover_color": ["#6f4fe0", "#4a32b9"],
+    "border_color": ["#977bf9", "#6448e8"],
+    "text_color": ["#ffffff", "#f8f6ff"],
+    "text_color_disabled": ["#b0a6d1", "#5a5570"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "fg_color": "transparent",
+    "text_color": ["#1c1626", "#f8f6ff"]
+  },
+  "CTkEntry": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#ffffff", "#221c30"],
+    "border_color": ["#d4c9f0", "#312847"],
+    "text_color": ["#1c1626", "#f6f3ff"],
+    "placeholder_text_color": ["#867da4", "#726a8c"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 10,
+    "border_width": 3,
+    "fg_color": ["#8264f6", "#5a3fd6"],
+    "border_color": ["#977bf9", "#6448e8"],
+    "hover_color": ["#6f4fe0", "#4a32b9"],
+    "checkmark_color": ["#f8f6ff", "#f8f6ff"],
+    "text_color": ["#1c1626", "#f8f6ff"],
+    "text_color_disabled": ["#a193c3", "#5a5570"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#d7cffa", "#372f4c"],
+    "progress_color": ["#8264f6", "#5a3fd6"],
+    "button_color": ["#ffffff", "#b5a7ff"],
+    "button_hover_color": ["#efe9ff", "#c5b9ff"],
+    "text_color": ["#1c1626", "#f8f6ff"],
+    "text_color_disabled": ["#a89dc9", "#5a5570"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#8264f6", "#5a3fd6"],
+    "border_color": ["#977bf9", "#6448e8"],
+    "hover_color": ["#6f4fe0", "#4a32b9"],
+    "text_color": ["#1c1626", "#f8f6ff"],
+    "text_color_disabled": ["#a193c3", "#5a5570"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#e1d9fb", "#332a49"],
+    "progress_color": ["#8264f6", "#5a3fd6"],
+    "border_color": ["#e1d9fb", "#332a49"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#e1d9fb", "#332a49"],
+    "progress_color": ["#8264f6", "#5a3fd6"],
+    "button_color": ["#6f4fe0", "#4a32b9"],
+    "button_hover_color": ["#5e40c8", "#3b249c"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 8,
+    "fg_color": ["#8264f6", "#5a3fd6"],
+    "button_color": ["#6f4fe0", "#4a32b9"],
+    "button_hover_color": ["#5e40c8", "#3b249c"],
+    "text_color": ["#ffffff", "#f8f6ff"],
+    "text_color_disabled": ["#b0a6d1", "#5a5570"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#ffffff", "#221c30"],
+    "border_color": ["#d4c9f0", "#312847"],
+    "button_color": ["#977bf9", "#6448e8"],
+    "button_hover_color": ["#6f4fe0", "#4a32b9"],
+    "text_color": ["#1c1626", "#f6f3ff"],
+    "text_color_disabled": ["#a89dc9", "#5a5570"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["#d4c9f0", "#3c3054"],
+    "button_hover_color": ["#beb1e0", "#493b66"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#d4c9f0", "#2a223a"],
+    "selected_color": ["#8264f6", "#5a3fd6"],
+    "selected_hover_color": ["#6f4fe0", "#4a32b9"],
+    "unselected_color": ["#e7defa", "#322a43"],
+    "unselected_hover_color": ["#d7cdf5", "#3d3351"],
+    "text_color": ["#ffffff", "#f8f6ff"],
+    "text_color_disabled": ["#b0a6d1", "#5a5570"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 8,
+    "border_width": 1,
+    "fg_color": ["#ffffff", "#1a1524"],
+    "border_color": ["#d4c9f0", "#2d243f"],
+    "text_color": ["#1c1626", "#f6f3ff"],
+    "scrollbar_button_color": ["#d4c9f0", "#3c3054"],
+    "scrollbar_button_hover_color": ["#beb1e0", "#493b66"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["#ebe4ff", "#181321"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["#efe8ff", "#211a30"],
+    "hover_color": ["#e0d5ff", "#29213d"],
+    "text_color": ["#1c1626", "#f8f6ff"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Pro Display",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Segoe UI",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Inter",
+      "size": 12,
+      "weight": "normal"
+    }
+  }
+}

--- a/app/ui/themes/teal.json
+++ b/app/ui/themes/teal.json
@@ -1,0 +1,155 @@
+{
+  "CTk": {
+    "fg_color": ["#eff7f5", "#101513"]
+  },
+  "CTkToplevel": {
+    "fg_color": ["#eff7f5", "#101513"]
+  },
+  "CTkFrame": {
+    "corner_radius": 12,
+    "border_width": 1,
+    "fg_color": ["#f8fbfa", "#1a201e"],
+    "top_fg_color": ["#e2eeeb", "#1f2624"],
+    "border_color": ["#c2d4cf", "#26302d"]
+  },
+  "CTkButton": {
+    "corner_radius": 8,
+    "border_width": 0,
+    "fg_color": ["#3ec1ad", "#2b7f72"],
+    "hover_color": ["#34a893", "#256d62"],
+    "border_color": ["#4ad5c0", "#2f9081"],
+    "text_color": ["#ffffff", "#f2fbf9"],
+    "text_color_disabled": ["#9db9b3", "#4a5f5b"]
+  },
+  "CTkLabel": {
+    "corner_radius": 0,
+    "fg_color": "transparent",
+    "text_color": ["#14201d", "#f2fbf9"]
+  },
+  "CTkEntry": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#ffffff", "#1f2623"],
+    "border_color": ["#c2d4cf", "#2f3a37"],
+    "text_color": ["#14201d", "#f1faf8"],
+    "placeholder_text_color": ["#738781", "#63736f"]
+  },
+  "CTkCheckBox": {
+    "corner_radius": 10,
+    "border_width": 3,
+    "fg_color": ["#3ec1ad", "#2b7f72"],
+    "border_color": ["#4ad5c0", "#2f9081"],
+    "hover_color": ["#34a893", "#256d62"],
+    "checkmark_color": ["#f2fbf9", "#f2fbf9"],
+    "text_color": ["#14201d", "#f2fbf9"],
+    "text_color_disabled": ["#8ca59f", "#4a5f5b"]
+  },
+  "CTkSwitch": {
+    "corner_radius": 1000,
+    "border_width": 3,
+    "button_length": 0,
+    "fg_color": ["#c5dad5", "#323d3a"],
+    "progress_color": ["#3ec1ad", "#2b7f72"],
+    "button_color": ["#ffffff", "#8dd7ca"],
+    "button_hover_color": ["#e2f6f2", "#9ce2d5"],
+    "text_color": ["#14201d", "#f2fbf9"],
+    "text_color_disabled": ["#91aaa4", "#4a5f5b"]
+  },
+  "CTkRadioButton": {
+    "corner_radius": 1000,
+    "border_width_checked": 6,
+    "border_width_unchecked": 3,
+    "fg_color": ["#3ec1ad", "#2b7f72"],
+    "border_color": ["#4ad5c0", "#2f9081"],
+    "hover_color": ["#34a893", "#256d62"],
+    "text_color": ["#14201d", "#f2fbf9"],
+    "text_color_disabled": ["#8ca59f", "#4a5f5b"]
+  },
+  "CTkProgressBar": {
+    "corner_radius": 1000,
+    "border_width": 0,
+    "fg_color": ["#d2e4df", "#2d3835"],
+    "progress_color": ["#3ec1ad", "#2b7f72"],
+    "border_color": ["#d2e4df", "#2d3835"]
+  },
+  "CTkSlider": {
+    "corner_radius": 1000,
+    "button_corner_radius": 1000,
+    "border_width": 6,
+    "button_length": 0,
+    "fg_color": ["#d2e4df", "#2d3835"],
+    "progress_color": ["#3ec1ad", "#2b7f72"],
+    "button_color": ["#34a893", "#256d62"],
+    "button_hover_color": ["#2b8f7b", "#1f574f"]
+  },
+  "CTkOptionMenu": {
+    "corner_radius": 8,
+    "fg_color": ["#3ec1ad", "#2b7f72"],
+    "button_color": ["#34a893", "#256d62"],
+    "button_hover_color": ["#2b8f7b", "#1f574f"],
+    "text_color": ["#ffffff", "#f2fbf9"],
+    "text_color_disabled": ["#9db9b3", "#4a5f5b"]
+  },
+  "CTkComboBox": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#ffffff", "#1f2623"],
+    "border_color": ["#c2d4cf", "#2f3a37"],
+    "button_color": ["#4ad5c0", "#2f9081"],
+    "button_hover_color": ["#34a893", "#256d62"],
+    "text_color": ["#14201d", "#f1faf8"],
+    "text_color_disabled": ["#91aaa4", "#4a5f5b"]
+  },
+  "CTkScrollbar": {
+    "corner_radius": 1000,
+    "border_spacing": 4,
+    "fg_color": "transparent",
+    "button_color": ["#c2d4cf", "#35403d"],
+    "button_hover_color": ["#a9c3bd", "#42504c"]
+  },
+  "CTkSegmentedButton": {
+    "corner_radius": 8,
+    "border_width": 2,
+    "fg_color": ["#c2d4cf", "#27322f"],
+    "selected_color": ["#3ec1ad", "#2b7f72"],
+    "selected_hover_color": ["#34a893", "#256d62"],
+    "unselected_color": ["#d8e9e4", "#303b38"],
+    "unselected_hover_color": ["#c7dbd5", "#3c4844"],
+    "text_color": ["#ffffff", "#f2fbf9"],
+    "text_color_disabled": ["#9db9b3", "#4a5f5b"]
+  },
+  "CTkTextbox": {
+    "corner_radius": 8,
+    "border_width": 1,
+    "fg_color": ["#ffffff", "#181e1c"],
+    "border_color": ["#c2d4cf", "#2b3532"],
+    "text_color": ["#14201d", "#f1faf8"],
+    "scrollbar_button_color": ["#c2d4cf", "#35403d"],
+    "scrollbar_button_hover_color": ["#a9c3bd", "#42504c"]
+  },
+  "CTkScrollableFrame": {
+    "label_fg_color": ["#e2eeeb", "#151c19"]
+  },
+  "DropdownMenu": {
+    "fg_color": ["#e6f4f1", "#1f2725"],
+    "hover_color": ["#d1ece6", "#27312e"],
+    "text_color": ["#14201d", "#f2fbf9"]
+  },
+  "CTkFont": {
+    "macOS": {
+      "family": "SF Pro Display",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Windows": {
+      "family": "Segoe UI",
+      "size": 12,
+      "weight": "normal"
+    },
+    "Linux": {
+      "family": "Inter",
+      "size": 12,
+      "weight": "normal"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated theming module with persisted appearance settings and bundled JSON color palettes for the new accent choices【F:app/ui/theme.py†L1-L104】【F:app/ui/themes/greyscale.json†L1-L40】
- wire the Devices / Settings page to apply themes immediately and adopt a cleaner grid-based layout across the configuration controls【F:app/ui/app.py†L8-L178】【F:app/ui/pages/devices_page.py†L1-L350】
- modernize the Latency, Sweep FR, Experimental, and Results pages with consistent spacing, section frames, and button styling【F:app/ui/pages/latency_page.py†L12-L228】【F:app/ui/pages/sweep_fr_page.py†L14-L238】【F:app/ui/pages/experimental_page.py†L6-L140】【F:app/ui/pages/results_page.py†L5-L35】
- update the README to describe how to switch appearance and accent themes and where settings are stored【F:README.md†L13-L18】

## Testing
- python -m compileall app【7bd1f2†L1-L34】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c459c2c88333b312f6ce528c1d06)