### PR TITLE
Fix theme refresh to handle subclassed widgets

### DIFF
--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -97,8 +97,14 @@ def _refresh_widget_tree(widget: tk.Misc) -> None:
 
     supported_options = _configurable_options(widget)
 
-    theme_key = widget.__class__.__name__
-    theme_values = ctk.ThemeManager.theme.get(theme_key, {})
+    theme_values: dict[str, object] = {}
+    for cls in widget.__class__.__mro__:
+        name = getattr(cls, "__name__", None)
+        if not name:
+            continue
+        if name in ctk.ThemeManager.theme:
+            theme_values = ctk.ThemeManager.theme.get(name, {})
+            break
     for option, value in theme_values.items():
         if option in {"macOS", "Windows", "Linux"}:
             continue


### PR DESCRIPTION
## Summary
- update theme refresh logic to search a widget's inheritance chain for matching theme definitions so subclassed widgets receive new colors

## Testing
- python -m compileall app/ui/theme.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dbf28b8c83339d8223380cb2c588)