### PR TITLE
Refactor pink noise generator into sweep test utilities

### DIFF
--- a/app/tests/sweep_fr/__init__.py
+++ b/app/tests/sweep_fr/__init__.py
@@ -2,5 +2,6 @@
 
 from .sweep_fr import run
 from .input_monitor import InputMonitorController, LevelState
+from .pink_noise import PinkNoiseGenerator
 
-__all__ = ["run", "InputMonitorController", "LevelState"]
+__all__ = ["run", "InputMonitorController", "LevelState", "PinkNoiseGenerator"]

--- a/app/tests/sweep_fr/pink_noise.py
+++ b/app/tests/sweep_fr/pink_noise.py
@@ -1,0 +1,69 @@
+"""Pink noise generation utilities for sweep frequency response tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import numpy as np
+
+
+@dataclass
+class PinkNoiseGenerator:
+    """Stateful pink noise generator using a simple IIR filter."""
+
+    gain: float = 0.25
+    _prev_white: np.ndarray = field(init=False, repr=False)
+    _prev_pink: np.ndarray = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset the filter history."""
+        self._prev_white = np.zeros(2, dtype=np.float32)
+        self._prev_pink = np.zeros(2, dtype=np.float32)
+
+    def generate(self, frames: int, samplerate: int | None = None) -> np.ndarray:
+        """Generate a block of pink noise samples.
+
+        Parameters
+        ----------
+        frames:
+            Number of samples to produce.
+        samplerate:
+            Unused currently; reserved for future calibration hooks.
+        """
+        if frames <= 0:
+            return np.zeros(0, dtype=np.float32)
+
+        if self._prev_white is None or self._prev_pink is None:
+            self.reset()
+
+        white = np.random.randn(frames).astype(np.float32)
+
+        b0, b1, b2 = 0.02109238, 0.07113478, 0.68873558
+        a1, a2 = -1.73472577, 0.7660066
+
+        _ = samplerate  # API compatibility for future calibration work.
+
+        w1, w2 = float(self._prev_white[0]), float(self._prev_white[1])
+        p1, p2 = float(self._prev_pink[0]), float(self._prev_pink[1])
+
+        pink = np.empty(frames, dtype=np.float32)
+        for i in range(frames):
+            w0 = float(white[i])
+            y = b0 * w0 + b1 * w1 + b2 * w2 - a1 * p1 - a2 * p2
+            pink[i] = y
+            w2, w1 = w1, w0
+            p2, p1 = p1, y
+
+        self._prev_white[...] = (w1, w2)
+        self._prev_pink[...] = (p1, p2)
+
+        pink -= np.mean(pink)
+        rms = float(np.sqrt(np.mean(pink**2)))
+        if rms > 1e-9:
+            pink *= float(self.gain) / rms
+        else:
+            pink.fill(0.0)
+
+        return pink.astype(np.float32, copy=False)

--- a/app/ui/pages/sweep_fr_page.py
+++ b/app/ui/pages/sweep_fr_page.py
@@ -5,7 +5,7 @@ import importlib
 import numpy as np
 from ...tests import sweep_fr
 from ...core.utils import ensure_dir
-from ...tests.sweep_fr import InputMonitorController, LevelState
+from ...tests.sweep_fr import InputMonitorController, LevelState, PinkNoiseGenerator
 
 _sounddevice_spec = importlib.util.find_spec("sounddevice")
 sounddevice = importlib.import_module("sounddevice") if _sounddevice_spec else None
@@ -33,6 +33,7 @@ class SweepFRPage(ctk.CTkFrame):
         self.pink_noise_playing = False
         self.pink_noise_thread = None
         self.pink_noise_stream = None
+        self.pink_noise_generator = PinkNoiseGenerator(gain=0.25)
 
         self.page_title_font = ctk.CTkFont(size=20, weight="bold")
         self.section_font = ctk.CTkFont(size=14, weight="bold")
@@ -378,11 +379,13 @@ class SweepFRPage(ctk.CTkFrame):
                 self.pink_noise_stream.stop()
                 self.pink_noise_stream.close()
                 self.pink_noise_stream = None
+            self.pink_noise_generator.reset()
             self.status_label.configure(text="Pink noise stopped.")
         else:
             self.pink_noise_playing = True
             self.pink_noise_button.configure(text="Stop Pink Noise")
             self.status_label.configure(text="Playing pink noise...")
+            self.pink_noise_generator.reset()
             self.start_pink_noise_thread()
 
     def start_pink_noise_thread(self):
@@ -396,7 +399,7 @@ class SweepFRPage(ctk.CTkFrame):
         blocksize = 1024
         # Create a stream that calls a callback to continuously fill with pink noise
         def callback(outdata, frames, time_info, status):
-            pink = self.generate_pink_noise(frames / samplerate, samplerate)
+            pink = self.pink_noise_generator.generate(frames, samplerate)
             outdata[:] = pink.reshape(-1, 1)
             # Real-time measurement (simulate level from pink noise itself)
             rms = np.sqrt(np.mean(pink ** 2))
@@ -420,14 +423,3 @@ class SweepFRPage(ctk.CTkFrame):
         while self.pink_noise_playing:
             time.sleep(0.1)
         # Stream will be stopped/closed by toggle_pink_noise
-
-    def generate_pink_noise(self, duration, samplerate):
-        n = int(duration * samplerate)
-        white = np.random.randn(n)
-        b = [0.02109238, 0.07113478, 0.68873558]
-        a = [1, -1.73472577, 0.7660066]
-        pink = np.zeros(n)
-        for i in range(3, n):
-            pink[i] = b[0] * white[i] + b[1] * white[i - 1] + b[2] * white[i - 2] - a[1] * pink[i - 1] - a[2] * pink[i - 2]
-        pink /= np.max(np.abs(pink)) + 1e-12
-        return pink.astype(np.float32)


### PR DESCRIPTION
## Summary
- add persistent filter state for the pink noise generator so the level monitor receives continuous noise
- normalize each block and reset state on start/stop to provide stable playback levels
- move the pink noise generator into the sweep_fr test utilities for reuse and to tidy the UI module

## Testing
- python -m compileall app/tests/sweep_fr/pink_noise.py app/ui/pages/sweep_fr_page.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e228d5e48333b197043c8d9a37f6)