### PR TITLE
Fix 5 user-reported issues: device refresh, Rough FR, mono dialog, fo…

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -234,6 +234,10 @@ pub struct LatencyTestRequest {
     /// output directory to save all results in one folder instead of separate folders
     #[serde(default)]
     pub shared_output_dir: Option<String>,
+    /// Optional: shared run tag (timestamp string) so all presets in a suite
+    /// resolve to the same output folder without needing a pre-existing directory.
+    #[serde(default)]
+    pub shared_run_tag: Option<String>,
 }
 
 impl Default for LatencyTestRequest {
@@ -250,6 +254,7 @@ impl Default for LatencyTestRequest {
             save_overall_bar_chart: true,
             calibrated_offset_ms: 0.0,
             shared_output_dir: None,
+            shared_run_tag: None,
         }
     }
 }
@@ -272,6 +277,10 @@ pub struct SweepFrRequest {
     pub mono_mode: bool,
     #[serde(default)]
     pub mono_side: Option<SweepMonoSide>,
+    /// When running guided mono sweep (L then R), pass the same tag to both
+    /// calls so they share one output folder instead of creating separate ones.
+    #[serde(default)]
+    pub shared_run_tag: Option<String>,
 }
 
 impl Default for SweepFrRequest {
@@ -614,16 +623,14 @@ impl AudioEngine {
             timestamp_utc: timestamp_string(),
         };
 
-        let run_tag = timestamp_filename();
-        // Use shared_output_dir if provided (for preset suite runs), otherwise resolve normally
+        // Prefer shared_run_tag (same folder for all presets in a suite), then
+        // shared_output_dir (legacy full-path approach), then generate a new tag.
+        let run_tag = request.shared_run_tag.clone()
+            .unwrap_or_else(timestamp_filename);
         let output_dir = if let Some(ref shared) = request.shared_output_dir {
             let shared_path = PathBuf::from(shared);
-            if shared_path.exists() {
-                shared_path
-            } else {
-                // Fall back to normal resolution if shared dir doesn't exist
-                resolve_measurement_output_dir(&request.output_dir, &item_name, &run_tag)
-            }
+            ensure_output_dir(&shared_path)?;
+            shared_path
         } else {
             resolve_measurement_output_dir(&request.output_dir, &item_name, &run_tag)
         };
@@ -1021,7 +1028,8 @@ impl AudioEngine {
             }),
             files: {
                 let mut files = serde_json::Map::<String, Value>::new();
-                let ts = timestamp_filename();
+                let ts = request.shared_run_tag.clone()
+                    .unwrap_or_else(timestamp_filename);
                 let output_dir = resolve_measurement_output_dir(&request.output_dir, &item_name, &ts);
 
                 if request.save_plots {

--- a/src/index.css
+++ b/src/index.css
@@ -708,3 +708,37 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+/* Mono sweep confirmation modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--card-border);
+  border-radius: 14px;
+  padding: 28px 32px;
+  max-width: 440px;
+  width: 90%;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+
+.modal-message {
+  color: var(--text-main);
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 0 0 20px 0;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}

--- a/src/ui/app-shell.tsx
+++ b/src/ui/app-shell.tsx
@@ -77,6 +77,11 @@ export function PawdioLabApp() {
               lastResult={controller.sweepLastResult}
               monitor={controller.inputMonitor}
               pinkNoisePlaying={controller.pinkNoisePlaying}
+              monoConfirmMessage={
+                controller.monoConfirmState?.message ?? null
+              }
+              onMonoConfirmOk={controller.confirmMonoDialog}
+              onMonoConfirmCancel={controller.cancelMonoDialog}
               onStartMonitor={() => run(controller.startInputMonitor())}
               onStopMonitor={() => run(controller.stopInputMonitor())}
               onStartPinkNoise={() => run(controller.startPinkNoise())}

--- a/src/ui/model.ts
+++ b/src/ui/model.ts
@@ -54,6 +54,7 @@ export type LatencyRequest = {
   saveOverallBarChart: boolean;
   calibratedOffsetMs: number;
   sharedOutputDir?: string;
+  sharedRunTag?: string;
 };
 
 export type LatencyCalibration = {
@@ -70,6 +71,7 @@ export type SweepRequest = {
   savePlots: boolean;
   saveSquiglink: boolean;
   monoMode: boolean;
+  sharedRunTag?: string;
 };
 
 export type BalanceRequest = {

--- a/src/ui/pages/sweep-fr-page.tsx
+++ b/src/ui/pages/sweep-fr-page.tsx
@@ -27,6 +27,9 @@ type SweepFrPageProps = {
     roughFrDb: number[];
   };
   pinkNoisePlaying: boolean;
+  monoConfirmMessage: string | null;
+  onMonoConfirmOk: () => void;
+  onMonoConfirmCancel: () => void;
   onStartMonitor: () => void;
   onStopMonitor: () => void;
   onStartPinkNoise: () => void;
@@ -49,6 +52,9 @@ export function SweepFrPage({
   lastResult,
   monitor,
   pinkNoisePlaying,
+  monoConfirmMessage,
+  onMonoConfirmOk,
+  onMonoConfirmCancel,
   onStartMonitor,
   onStopMonitor,
   onStartPinkNoise,
@@ -77,8 +83,8 @@ export function SweepFrPage({
     ) {
       return null;
     }
-    const minHz = Math.max(1, freqs[0]);
-    const maxHz = Math.max(minHz + 1, freqs[freqs.length - 1]);
+    const minHz = 20;
+    const maxHz = 20000;
     const minLog = Math.log10(minHz);
     const maxLog = Math.log10(maxHz);
     const spanLog = Math.max(1e-6, maxLog - minLog);
@@ -119,7 +125,7 @@ export function SweepFrPage({
     const last = points[points.length - 1];
     linePath += ` T ${last.x.toFixed(2)} ${last.y.toFixed(2)}`;
 
-    const xGuides = [20, 100, 1000, 10000]
+    const xGuides = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000]
       .map((freq) => {
         const x = ((Math.log10(freq) - minLog) / spanLog) * 200;
         if (!Number.isFinite(x) || x < 0 || x > 200) {
@@ -143,6 +149,29 @@ export function SweepFrPage({
 
   return (
     <div className="page-stack">
+      {monoConfirmMessage && (
+        <div className="modal-overlay">
+          <div className="modal-box">
+            <p className="modal-message">{monoConfirmMessage}</p>
+            <div className="modal-actions">
+              <button
+                type="button"
+                className="skin-btn secondary"
+                onClick={onMonoConfirmCancel}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="skin-btn"
+                onClick={onMonoConfirmOk}
+              >
+                OK
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <section className="page-card">
         <h2 className="section-heading">Sweep Frequency Response</h2>
 

--- a/src/ui/use-pawdio-lab.ts
+++ b/src/ui/use-pawdio-lab.ts
@@ -630,6 +630,14 @@ export function usePawdioLabController() {
   );
   const [pinkNoisePlaying, setPinkNoisePlaying] = useState(false);
 
+  type MonoConfirmState = {
+    message: string;
+    resolve: () => void;
+    reject: () => void;
+  };
+  const [monoConfirmState, setMonoConfirmState] =
+    useState<MonoConfirmState | null>(null);
+
   const [balanceRequest, setBalanceRequest] = useState(
     mergeWithDefaults(defaultBalanceRequest, persistedUiState?.balanceRequest),
   );
@@ -789,17 +797,16 @@ export function usePawdioLabController() {
       ) {
         merged.inputDeviceIndex = null;
       }
-      if (
-        merged.outputDeviceIndex === null &&
-        devices.defaultOutputIndex !== null
-      ) {
+      // Always update to current system defaults on device refresh
+      if (devices.defaultOutputIndex !== null) {
         merged.outputDeviceIndex = devices.defaultOutputIndex;
+      } else if (merged.outputDeviceIndex === null) {
+        merged.outputDeviceIndex = null;
       }
-      if (
-        merged.inputDeviceIndex === null &&
-        devices.defaultInputIndex !== null
-      ) {
+      if (devices.defaultInputIndex !== null) {
         merged.inputDeviceIndex = devices.defaultInputIndex;
+      } else if (merged.inputDeviceIndex === null) {
+        merged.inputDeviceIndex = null;
       }
       const committed = await invoke<AudioSettings>("set_audio_settings", {
         settings: merged,
@@ -1016,12 +1023,14 @@ export function usePawdioLabController() {
     setLatencyExportSuite([]);
     appendLog(`[latency] preset suite started (${presets.length})`);
 
-    // Create a shared output directory for all preset results
+    // Use a shared run tag so all presets land in the same output folder
+    const sharedRunTag = exportTimestampTag();
     let sharedOutputDir: string | undefined;
     if (latencyRequest.outputDir) {
-      const timestamp = exportTimestampTag();
-      sharedOutputDir = `${latencyRequest.outputDir}/latency_suite_${timestamp}`;
+      sharedOutputDir = `${latencyRequest.outputDir}/latency_suite_${sharedRunTag}`;
       appendLog(`[latency] shared output directory -> ${sharedOutputDir}`);
+    } else {
+      appendLog(`[latency] shared run tag -> ${sharedRunTag}`);
     }
 
     try {
@@ -1031,6 +1040,7 @@ export function usePawdioLabController() {
           ...requestForPreset(latencyRequest, preset),
           saveOverallBarChart: false,
           sharedOutputDir,
+          sharedRunTag,
         };
         appendLog(`[latency] ${preset.label} started`);
         const { report, calibratedOffsetMs } = await runLatencyOnce(
@@ -1165,19 +1175,40 @@ export function usePawdioLabController() {
     return invoke<TestPayload>("run_sweep_fr_test", { request });
   }
 
+  function requestMonoConfirm(message: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      setMonoConfirmState({ message, resolve, reject });
+    });
+  }
+
+  function confirmMonoDialog() {
+    if (monoConfirmState) {
+      monoConfirmState.resolve();
+      setMonoConfirmState(null);
+    }
+  }
+
+  function cancelMonoDialog() {
+    if (monoConfirmState) {
+      monoConfirmState.reject(new Error("cancelled"));
+      setMonoConfirmState(null);
+    }
+  }
+
   async function runSweepFrTest() {
     if (running) {
       return;
     }
     const monoGuided = sweepRequest.monoMode;
-    if (
-      monoGuided &&
-      !window.confirm(
-        "Mono mode: place the LEFT side on the measurement position, then click OK to run the LEFT sweep.",
-      )
-    ) {
-      appendLog("[SWEEP FR] mono run cancelled before LEFT sweep");
-      return;
+    if (monoGuided) {
+      try {
+        await requestMonoConfirm(
+          "Mono mode: place the LEFT earphone/driver on the measurement position, then click OK to run the LEFT sweep.",
+        );
+      } catch {
+        appendLog("[SWEEP FR] mono run cancelled before LEFT sweep");
+        return;
+      }
     }
     try {
       await invoke("stop_input_monitor");
@@ -1212,17 +1243,21 @@ export function usePawdioLabController() {
         setSweepLastResult(normalized);
         appendResult(normalized);
       } else {
+        const sharedRunTag = exportTimestampTag();
         appendLog("[SWEEP FR] running LEFT sweep");
         const leftPayload = await invokeSweepFrRaw({
           ...sweepRequest,
           monoSide: "left",
+          sharedRunTag,
         });
         appendLog("[SWEEP FR] LEFT sweep complete");
 
-        const proceedRight = window.confirm(
-          "Now place the RIGHT side on the measurement position, then click OK to run the RIGHT sweep.",
-        );
-        if (!proceedRight) {
+        setRunning(false);
+        try {
+          await requestMonoConfirm(
+            "Now place the RIGHT earphone/driver on the measurement position, then click OK to run the RIGHT sweep.",
+          );
+        } catch {
           const leftOnly = {
             ...leftPayload,
             timestamp: legacyTimestamp(leftPayload.timestamp),
@@ -1232,11 +1267,13 @@ export function usePawdioLabController() {
           appendLog("[SWEEP FR] mono run stopped after LEFT sweep");
           return;
         }
+        setRunning(true);
 
         appendLog("[SWEEP FR] running RIGHT sweep");
         const rightPayload = await invokeSweepFrRaw({
           ...sweepRequest,
           monoSide: "right",
+          sharedRunTag,
         });
         const combinedPayload = combineGuidedMonoSweepPayload(
           leftPayload,
@@ -1867,6 +1904,9 @@ export function usePawdioLabController() {
     sweepLastResult,
     inputMonitor,
     pinkNoisePlaying,
+    monoConfirmState,
+    confirmMonoDialog,
+    cancelMonoDialog,
     startInputMonitor,
     stopInputMonitor,
     startPinkNoise,


### PR DESCRIPTION
…lder naming

- Fix 1: Refresh Devices now always updates to system default audio device instead of only when no device was previously selected, so newly connected dongles are auto-detected on Mac.

- Fix 2: Live Rough FR X-axis now spans the full 20 Hz–20 kHz range (matching actual FR plots) with additional frequency guide lines.

- Fix 3: Mono sweep confirmation dialogs replaced window.confirm() with proper React modal overlays that correctly pause execution until the user clicks OK or Cancel.

- Fix 4: Guided mono sweep (L then R) now passes a sharedRunTag to both Rust calls so both sides save into the same output folder, with file names (sweep_fr_left_avg_*, sweep_fr_right_avg_*) indicating which channel is which.

- Fix 5: Running multiple latency presets now always generates a shared run tag so all beep results are written to the same folder instead of separate per-beep folders. Also fixes the shared_output_dir path to create the directory when needed (removed broken exists() guard).

https://claude.ai/code/session_01LJf4bxvJQtZPDjvbiSjUft