### PR TITLE
fix: add shared_run_tag to SweepFrRequest Default impl

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -296,6 +296,7 @@ impl Default for SweepFrRequest {
             save_squiglink: true,
             mono_mode: false,
             mono_side: None,
+            shared_run_tag: None,
         }
     }
 }


### PR DESCRIPTION
Resolves Rust compile error E0063: missing field 'shared_run_tag' in initializer of 'SweepFrRequest'.

https://claude.ai/code/session_01LJf4bxvJQtZPDjvbiSjUft