### PR TITLE
redesign: flatten card hierarchy, link-style nav, tighter spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,10 @@
   --danger-button-bottom: #7e313a;
   --select-arrow: #8da7d2;
   --nav-text: #dbe7fd;
+  --nav-item-text: #8fa4c8;
+  --nav-item-hover-bg: rgba(79, 158, 242, 0.07);
+  --nav-item-active-bg: rgba(79, 158, 242, 0.14);
+  --nav-item-active-border: var(--accent-strong);
   --chip-border: rgba(101, 124, 158, 0.6);
   --chip-bg: rgba(39, 47, 64, 0.85);
   --chip-text: #d9e5fa;
@@ -103,6 +107,9 @@
   --secondary-button-bottom: #e5edf8;
   --secondary-button-border: rgba(144, 164, 193, 0.6);
   --select-arrow: #6b82a8;
+  --nav-item-text: #5a6e8a;
+  --nav-item-hover-bg: rgba(42, 116, 199, 0.07);
+  --nav-item-active-bg: rgba(42, 116, 199, 0.12);
   --chip-border: rgba(146, 167, 196, 0.72);
   --chip-bg: rgba(237, 244, 252, 0.95);
   --chip-text: #27425f;
@@ -136,6 +143,8 @@
   --button-accent-hover-bottom: #2d9199;
   --button-accent-active-top: #4ec3cb;
   --button-accent-active-bottom: #329ea7;
+  --nav-item-active-bg: rgba(78, 195, 203, 0.14);
+  --nav-item-hover-bg: rgba(78, 195, 203, 0.07);
 }
 
 :root[data-accent="greyscale"] {
@@ -149,6 +158,8 @@
   --button-accent-hover-bottom: #667384;
   --button-accent-active-top: #9da8b8;
   --button-accent-active-bottom: #748192;
+  --nav-item-active-bg: rgba(164, 175, 189, 0.14);
+  --nav-item-hover-bg: rgba(164, 175, 189, 0.07);
 }
 
 :root[data-accent="purple"] {
@@ -162,6 +173,8 @@
   --button-accent-hover-bottom: #725fc1;
   --button-accent-active-top: #a48cf4;
   --button-accent-active-bottom: #816ad8;
+  --nav-item-active-bg: rgba(164, 140, 244, 0.14);
+  --nav-item-hover-bg: rgba(164, 140, 244, 0.07);
 }
 
 * {
@@ -205,8 +218,8 @@ body {
 
 .app-layout {
   display: grid;
-  grid-template-columns: minmax(220px, 380px) minmax(0, 1fr);
-  gap: 14px;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  gap: 12px;
   height: calc(100vh - 20px);
 }
 
@@ -219,78 +232,75 @@ body {
   border: 1px solid var(--sidebar-border);
   border-radius: 10px;
   box-shadow: var(--shadow-panel);
-  padding: 18px 12px;
+  padding: 20px 14px 16px;
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
 .sidebar-title {
-  font-size: 34px;
+  font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
   margin: 0;
+  color: var(--text-strong);
 }
 
 .sidebar-subtitle {
-  margin: 0;
+  margin: 3px 0 0;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .sidebar-nav {
-  margin-top: 10px;
+  margin-top: 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 2px;
 }
 
 .nav-btn {
   width: 100%;
-  border: 1px solid transparent;
-  border-radius: 7px;
+  border: none;
+  border-left: 3px solid transparent;
+  border-radius: 6px;
   font: inherit;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
-  color: var(--nav-text);
-  background: linear-gradient(
-    180deg,
-    var(--button-accent-top),
-    var(--button-accent-bottom)
-  );
-  padding: 8px 10px;
+  color: var(--nav-item-text);
+  background: transparent;
+  padding: 8px 10px 8px 9px;
   cursor: pointer;
+  text-align: left;
   transition:
-    background 120ms ease,
-    border-color 120ms ease,
-    transform 120ms ease;
+    background 100ms ease,
+    color 100ms ease,
+    border-color 100ms ease;
 }
 
 .nav-btn:hover {
-  background: linear-gradient(
-    180deg,
-    var(--button-accent-hover-top),
-    var(--button-accent-hover-bottom)
-  );
-  transform: translateY(-1px);
+  background: var(--nav-item-hover-bg);
+  color: var(--text-main);
 }
 
 .nav-btn.is-active {
-  border-color: var(--accent-strong);
-  background: linear-gradient(
-    180deg,
-    var(--button-accent-active-top),
-    var(--button-accent-active-bottom)
-  );
-  color: #ffffff;
+  border-left-color: var(--nav-item-active-border);
+  background: var(--nav-item-active-bg);
+  color: var(--accent-strong);
+  font-weight: 600;
 }
 
 .sidebar-footer {
   margin-top: auto;
   padding-top: 12px;
+  border-top: 1px solid var(--section-divider);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .main-column {
@@ -312,25 +322,47 @@ body {
   border: 1px solid var(--card-border);
   border-radius: 10px;
   box-shadow: var(--shadow-panel);
-  padding: 14px;
+  padding: 20px;
+}
+
+.page-section {
+  padding-top: 20px;
+}
+
+.page-section:first-child {
+  padding-top: 0;
 }
 
 .section-heading {
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 700;
-  margin: 0 0 10px;
+  margin: 0 0 16px;
+  color: var(--text-strong);
+  letter-spacing: -0.01em;
 }
 
 .section-subheading {
-  font-size: 15px;
-  font-weight: 700;
-  margin: 0 0 10px;
+  font-size: 12px;
+  font-weight: 600;
+  margin: 0 0 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .section-divider {
   border: 0;
   border-top: 1px solid var(--section-divider);
-  margin: 10px 0 12px;
+  margin: 18px 0 0;
+}
+
+.section-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
 }
 
 .field-row {
@@ -346,19 +378,19 @@ body {
 
 .field-grid-2 {
   display: grid;
-  gap: 10px;
+  gap: 12px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .field-grid-3 {
   display: grid;
-  gap: 10px;
+  gap: 12px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .field-grid-4 {
   display: grid;
-  gap: 10px;
+  gap: 12px;
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
@@ -653,6 +685,7 @@ body {
   gap: 6px;
   font-size: 12px;
   color: var(--status-text);
+  flex: 1;
 }
 
 .status-dot {
@@ -675,10 +708,26 @@ body {
   gap: 8px;
 }
 
+.action-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 14px;
+}
+
 .muted {
   color: var(--text-muted);
   font-size: 13px;
+  margin: 0;
 }
+
+/* Spacing utilities */
+.mt-8  { margin-top: 8px; }
+.mt-10 { margin-top: 10px; }
+.mt-12 { margin-top: 12px; }
+.mt-16 { margin-top: 16px; }
+.mb-12 { margin-bottom: 12px; }
 
 @media (max-width: 1280px) {
   .field-grid-4 {

--- a/src/ui/components/sidebar.tsx
+++ b/src/ui/components/sidebar.tsx
@@ -14,7 +14,6 @@ export function Sidebar({
   running,
   experimentalEnabled,
   onSelectPage,
-  onRefreshDevices,
   onStopTest,
 }: SidebarProps) {
   const visiblePages = experimentalEnabled
@@ -24,14 +23,14 @@ export function Sidebar({
   return (
     <aside className="sidebar-shell">
       <h1 className="sidebar-title">PawdioLab</h1>
-      <p className="sidebar-subtitle">Desktop Audio Diagnostics</p>
+      <p className="sidebar-subtitle">Audio Diagnostics</p>
 
       <nav className="sidebar-nav" aria-label="Primary">
         {visiblePages.map((item) => (
           <button
             key={item.key}
             type="button"
-            className={`nav-btn ${activePage === item.key ? "is-active" : ""}`.trim()}
+            className={`nav-btn${activePage === item.key ? " is-active" : ""}`}
             onClick={() => onSelectPage(item.key)}
           >
             {item.label}
@@ -46,18 +45,11 @@ export function Sidebar({
         </span>
         <button
           type="button"
-          className="skin-btn secondary"
-          onClick={onRefreshDevices}
-        >
-          Refresh Devices
-        </button>
-        <button
-          type="button"
           className="skin-btn danger"
           disabled={!running}
           onClick={onStopTest}
         >
-          Stop Test
+          Stop
         </button>
       </div>
     </aside>

--- a/src/ui/pages/devices-page.tsx
+++ b/src/ui/pages/devices-page.tsx
@@ -70,7 +70,7 @@ export function DevicesPage({
       <section className="page-card">
         <h2 className="section-heading">Devices / Settings</h2>
 
-        <section className="page-card">
+        <section className="page-section">
           <h3 className="section-subheading">Signal Settings</h3>
 
           <div className="field-grid-2">
@@ -104,7 +104,7 @@ export function DevicesPage({
             </label>
           </div>
 
-          <div className="field-grid-2" style={{ marginTop: 10 }}>
+          <div className="field-grid-2 mt-10">
             <LabeledNumberInput
               label="Signal Duration (s)"
               value={draft.durationSecs}
@@ -130,7 +130,8 @@ export function DevicesPage({
               </select>
             </label>
           </div>
-          <label className="field-row" style={{ marginTop: 10 }}>
+
+          <label className="field-row mt-10">
             <span className="field-label">Item Name</span>
             <input
               className="skin-input"
@@ -145,7 +146,7 @@ export function DevicesPage({
             />
           </label>
 
-          <div className="row-end" style={{ marginTop: 12 }}>
+          <div className="row-end mt-12">
             <button
               type="button"
               className="skin-btn"
@@ -156,7 +157,8 @@ export function DevicesPage({
           </div>
         </section>
 
-        <section className="page-card" style={{ marginTop: 12 }}>
+        <hr className="section-divider" />
+        <section className="page-section">
           <h3 className="section-subheading">Audio Devices</h3>
 
           <div className="field-grid-4">
@@ -188,12 +190,12 @@ export function DevicesPage({
                 className="skin-btn secondary"
                 onClick={onRefreshDevices}
               >
-                Refresh Devices
+                Refresh
               </button>
             </div>
           </div>
 
-          <label className="field-row" style={{ marginTop: 10 }}>
+          <label className="field-row mt-10">
             <span className="field-label">Input Device</span>
             <select
               className="skin-select"
@@ -232,7 +234,8 @@ export function DevicesPage({
           />
         </section>
 
-        <section className="page-card" style={{ marginTop: 12 }}>
+        <hr className="section-divider" />
+        <section className="page-section">
           <h3 className="section-subheading">Appearance</h3>
 
           <div className="field-grid-2">
@@ -268,7 +271,7 @@ export function DevicesPage({
             </label>
           </div>
 
-          <label className="toggle-line" style={{ marginTop: 10 }}>
+          <label className="toggle-line mt-10">
             <input
               type="checkbox"
               checked={experimentalEnabled}

--- a/src/ui/pages/experimental-page.tsx
+++ b/src/ui/pages/experimental-page.tsx
@@ -74,7 +74,7 @@ export function ExperimentalPage({
                 }
               />
             </label>
-            <div className="row-end" style={{ marginTop: 12 }}>
+            <div className="row-end mt-12">
               <RunButton disabled={running} onClick={onRunBalance} />
             </div>
           </section>
@@ -114,17 +114,17 @@ export function ExperimentalPage({
                 </select>
               </label>
             </div>
-            <div className="row-end" style={{ marginTop: 12 }}>
+            <div className="row-end mt-12">
               <RunButton disabled={running} onClick={onRunCrosstalk} />
             </div>
           </section>
 
           <section className="page-card">
             <h3 className="section-subheading">THD</h3>
-            <p className="muted" style={{ marginTop: 0 }}>
+            <p className="muted">
               Runs 100 / 1k / 6k Hz distortion measurements.
             </p>
-            <div className="field-grid-2" style={{ marginTop: 10 }}>
+            <div className="field-grid-2 mt-10">
               <label className="field-row">
                 <span className="field-label">Tones (Hz)</span>
                 <input
@@ -152,17 +152,17 @@ export function ExperimentalPage({
                 />
               </label>
             </div>
-            <div className="row-end" style={{ marginTop: 12 }}>
+            <div className="row-end mt-12">
               <RunButton disabled={running} onClick={onRunThd} />
             </div>
           </section>
 
           <section className="page-card">
             <h3 className="section-subheading">Isolation</h3>
-            <p className="muted" style={{ marginTop: 0 }}>
+            <p className="muted">
               Measures inside to outside isolation.
             </p>
-            <div className="field-grid-2" style={{ marginTop: 10 }}>
+            <div className="field-grid-2 mt-10">
               <label className="field-row">
                 <span className="field-label">Noise Duration (s)</span>
                 <input
@@ -197,16 +197,17 @@ export function ExperimentalPage({
                 />
               </label>
             </div>
-            <div className="row-end" style={{ marginTop: 12 }}>
+            <div className="row-end mt-12">
               <RunButton disabled={running} onClick={onRunIsolation} />
             </div>
           </section>
         </div>
 
-        <section className="page-card" style={{ marginTop: 12 }}>
+        <hr className="section-divider" />
+        <section className="page-section">
           <h3 className="section-subheading">Experimental Results</h3>
           <div className="placeholder-box" style={{ minHeight: 220 }} />
-          <div className="row-end" style={{ marginTop: 12 }}>
+          <div className="row-end mt-12">
             <button type="button" className="skin-btn secondary" disabled>
               Export LAST (JSON)
             </button>

--- a/src/ui/pages/latency-page.tsx
+++ b/src/ui/pages/latency-page.tsx
@@ -176,7 +176,7 @@ export function LatencyPage({
       <section className="page-card">
         <h2 className="section-heading">Latency</h2>
 
-        <section className="page-card">
+        <section className="page-section">
           <h3 className="section-subheading">Run Delay Tests</h3>
 
           <div className="chip-row">
@@ -197,7 +197,7 @@ export function LatencyPage({
             ))}
           </div>
 
-          <div className="range-line" style={{ marginTop: 12 }}>
+          <div className="range-line mt-12">
             <span className="field-label">Repeats</span>
             <input
               className="skin-range"
@@ -219,7 +219,7 @@ export function LatencyPage({
             <span>{request.repeats}</span>
           </div>
 
-          <div className="field-grid-4" style={{ marginTop: 12 }}>
+          <div className="field-grid-4 mt-12">
             <LabeledNumberInput
               label="Frequency (Hz)"
               value={request.frequencyHz}
@@ -268,7 +268,7 @@ export function LatencyPage({
             />
           </div>
 
-          <div className="field-grid-2" style={{ marginTop: 12 }}>
+          <div className="field-grid-2 mt-12">
             <label className="toggle-line">
               <input
                 type="checkbox"
@@ -297,7 +297,7 @@ export function LatencyPage({
             </label>
           </div>
 
-          <div className="field-grid-4" style={{ marginTop: 12 }}>
+          <div className="field-grid-4 mt-12">
             <label className="field-row" style={{ gridColumn: "span 3" }}>
               <span className="field-label">Output Folder</span>
               <input
@@ -320,15 +320,7 @@ export function LatencyPage({
             </div>
           </div>
 
-          <div
-            style={{
-              marginTop: 12,
-              display: "flex",
-              justifyContent: "space-between",
-              gap: 10,
-              flexWrap: "wrap",
-            }}
-          >
+          <div className="action-row">
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <button
                 type="button"
@@ -369,26 +361,29 @@ export function LatencyPage({
                 Run ALL
               </button>
             </div>
-            <button
-              type="button"
-              className="skin-btn secondary"
-              disabled={!report || running}
-              onClick={onSaveReport}
-            >
-              Save Text Report
-            </button>
-            <button
-              type="button"
-              className="skin-btn secondary"
-              disabled={!report || running}
-              onClick={onExportCsv}
-            >
-              Export CSV
-            </button>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <button
+                type="button"
+                className="skin-btn secondary"
+                disabled={!report || running}
+                onClick={onSaveReport}
+              >
+                Save Text Report
+              </button>
+              <button
+                type="button"
+                className="skin-btn secondary"
+                disabled={!report || running}
+                onClick={onExportCsv}
+              >
+                Export CSV
+              </button>
+            </div>
           </div>
         </section>
 
-        <section className="page-card" style={{ marginTop: 12 }}>
+        <hr className="section-divider" />
+        <section className="page-section">
           <h3 className="section-subheading">Results Summary</h3>
 
           <div className="metric-grid">
@@ -408,7 +403,7 @@ export function LatencyPage({
             </article>
           </div>
 
-          <div style={{ marginTop: 10 }}>
+          <div className="mt-10">
             <p className="field-label">
               Detailed Breakdown | Progress {progressPercent}% | Signal{" "}
               {request.signal}
@@ -419,7 +414,8 @@ export function LatencyPage({
           </div>
         </section>
 
-        <section className="page-card" style={{ marginTop: 12 }}>
+        <hr className="section-divider" />
+        <section className="page-section">
           <h3 className="section-subheading">Calibration</h3>
 
           <div className="chip-row">
@@ -445,7 +441,7 @@ export function LatencyPage({
             ))}
           </div>
 
-          <div className="range-line" style={{ marginTop: 12 }}>
+          <div className="range-line mt-12">
             <span className="field-label">Repeats</span>
             <input
               className="skin-range"
@@ -463,7 +459,7 @@ export function LatencyPage({
             <span>{calibrationRepeats}</span>
           </div>
 
-          <div className="field-grid-2" style={{ marginTop: 12 }}>
+          <div className="field-grid-2 mt-12">
             <button
               type="button"
               className="skin-btn secondary"
@@ -494,7 +490,7 @@ export function LatencyPage({
             </button>
           </div>
 
-          <div style={{ marginTop: 10 }}>
+          <div className="mt-10">
             <p className="field-label">Calibration Offsets</p>
             <div className="scroll-box">
               <pre className="mono-pre">{calibrationText}</pre>

--- a/src/ui/pages/results-page.tsx
+++ b/src/ui/pages/results-page.tsx
@@ -12,46 +12,33 @@ export function ResultsPage({
   return (
     <div className="page-stack">
       <section className="page-card">
-        <h2 className="section-heading">Results / Export</h2>
-
-        {/* Log Tab - Only tab now */}
-        <section className="page-card">
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              gap: 10,
-              flexWrap: "wrap",
-            }}
-          >
-            <h3 className="section-subheading" style={{ marginBottom: 0 }}>
-              Logs
-            </h3>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              <button
-                type="button"
-                className="skin-btn secondary"
-                onClick={onCopyLog}
-              >
-                Copy Log
-              </button>
-              <button
-                type="button"
-                className="skin-btn secondary"
-                onClick={onClearLog}
-              >
-                Clear Log
-              </button>
-            </div>
+        <div className="section-header-row">
+          <h2 className="section-heading" style={{ marginBottom: 0 }}>
+            Logs
+          </h2>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              type="button"
+              className="skin-btn secondary"
+              onClick={onCopyLog}
+            >
+              Copy Log
+            </button>
+            <button
+              type="button"
+              className="skin-btn secondary"
+              onClick={onClearLog}
+            >
+              Clear Log
+            </button>
           </div>
+        </div>
 
-          <div className="scroll-box" style={{ marginTop: 10 }}>
-            <pre className="mono-pre">
-              {logText.length > 0 ? logText : "No logs yet."}
-            </pre>
-          </div>
-        </section>
+        <div className="scroll-box">
+          <pre className="mono-pre">
+            {logText.length > 0 ? logText : "No logs yet."}
+          </pre>
+        </div>
       </section>
     </div>
   );

--- a/src/ui/pages/sweep-fr-page.tsx
+++ b/src/ui/pages/sweep-fr-page.tsx
@@ -172,10 +172,11 @@ export function SweepFrPage({
           </div>
         </div>
       )}
+
       <section className="page-card">
         <h2 className="section-heading">Sweep Frequency Response</h2>
 
-        <section className="page-card">
+        <section className="page-section">
           <h3 className="section-subheading">Sweep Settings</h3>
 
           <div className="field-grid-4">
@@ -236,7 +237,7 @@ export function SweepFrPage({
             </div>
           </div>
 
-          <div className="field-grid-2" style={{ marginTop: 12 }}>
+          <div className="field-grid-2 mt-12">
             <LabeledNumberInput
               label="Amplitude"
               value={request.amplitude}
@@ -296,7 +297,7 @@ export function SweepFrPage({
             </div>
           </div>
 
-          <div className="field-grid-4" style={{ marginTop: 12 }}>
+          <div className="field-grid-4 mt-12">
             <label className="field-row" style={{ gridColumn: "span 3" }}>
               <span className="field-label">Output Folder</span>
               <input
@@ -328,180 +329,175 @@ export function SweepFrPage({
           </div>
         </section>
 
-        <div className="field-grid-2" style={{ marginTop: 12 }}>
-          <section className="page-card">
-            <h3 className="section-subheading">Input Level Monitor</h3>
-            <p className="muted" style={{ marginTop: 0 }}>
-              {monitor.status}
-            </p>
-            <div className="level-meter" style={{ marginBottom: 12 }}>
-              <div className="level-meter-grid" />
-              <div className="level-meter-bars">
-                {meterHistory.map((level, index) => (
-                  <span
-                    key={`meter-${index}`}
-                    className={`level-meter-bar ${
-                      level > 0.92 ? "is-hot" : level > 0.72 ? "is-warm" : ""
-                    }`.trim()}
-                    style={{
-                      height: `${Math.max(8, level * 100)}%`,
-                    }}
-                  />
-                ))}
-              </div>
-              <span
-                className="level-meter-peak"
-                style={{ left: `${peakNorm * 100}%` }}
-              />
-            </div>
-            <div className="field-grid-3">
-              <div className="field-row">
-                <span className="field-label">Current Level</span>
-                <strong>{monitor.currentDbfs.toFixed(1)} dBFS</strong>
-              </div>
-              <div className="field-row">
-                <span className="field-label">Peak Level</span>
-                <strong>{monitor.peakDbfs.toFixed(1)} dBFS</strong>
-              </div>
-              <div className="field-row">
-                <span className="field-label">SPL Estimate</span>
-                <strong>{monitor.splEstimate.toFixed(1)} dB SPL</strong>
-              </div>
-            </div>
-            {monitor.clipCount > 0 && (
-              <p className="muted" style={{ color: "#ff8e8e", marginTop: 8 }}>
-                Clipping detected ({monitor.clipCount})
-              </p>
-            )}
-            <div
-              style={{
-                display: "flex",
-                gap: 8,
-                marginTop: 12,
-                flexWrap: "wrap",
-              }}
-            >
-              <button
-                type="button"
-                className="skin-btn secondary"
-                onClick={monitor.monitoring ? onStopMonitor : onStartMonitor}
-              >
-                {monitor.monitoring ? "Stop Monitoring" : "Start Monitoring"}
-              </button>
-              <button
-                type="button"
-                className="skin-btn secondary"
-                disabled={running}
-                onClick={pinkNoisePlaying ? onStopPinkNoise : onStartPinkNoise}
-              >
-                {pinkNoisePlaying ? "Stop Pink Noise" : "Play Pink Noise"}
-              </button>
-              <button
-                type="button"
-                className="skin-btn secondary"
-                onClick={onResetPeak}
-              >
-                Reset Peak
-              </button>
-            </div>
-          </section>
-
-          <section className="page-card live-rough-card">
-            <h3 className="section-subheading">Live Rough FR (Pink Noise)</h3>
-            <p className="muted" style={{ marginTop: 0 }}>
-              {pinkNoisePlaying
-                ? "Live preview running"
-                : "Start Pink Noise + Monitoring"}
-            </p>
-            <div className="level-meter live-rough-meter">
-              <svg viewBox="0 0 200 100" className="live-rough-svg">
-                <line
-                  x1="0"
-                  y1="10"
-                  x2="200"
-                  y2="10"
-                  stroke="var(--level-grid)"
-                  strokeWidth="0.6"
-                />
-                <line
-                  x1="0"
-                  y1="50"
-                  x2="200"
-                  y2="50"
-                  stroke="var(--level-grid)"
-                  strokeWidth="1"
-                />
-                <line
-                  x1="0"
-                  y1="90"
-                  x2="200"
-                  y2="90"
-                  stroke="var(--level-grid)"
-                  strokeWidth="0.6"
-                />
-                {(roughFrGraph?.xGuides ?? []).map((guide) => (
-                  <g key={`guide-${guide.label}-${guide.x.toFixed(2)}`}>
-                    <line
-                      x1={guide.x}
-                      y1="8"
-                      x2={guide.x}
-                      y2="92"
-                      stroke="var(--level-grid)"
-                      strokeWidth="0.45"
+        <hr className="section-divider" />
+        <section className="page-section">
+          <div className="field-grid-2">
+            <section className="page-card">
+              <h3 className="section-subheading">Input Level Monitor</h3>
+              <p className="muted">{monitor.status}</p>
+              <div className="level-meter mb-12">
+                <div className="level-meter-grid" />
+                <div className="level-meter-bars">
+                  {meterHistory.map((level, index) => (
+                    <span
+                      key={`meter-${index}`}
+                      className={`level-meter-bar ${
+                        level > 0.92 ? "is-hot" : level > 0.72 ? "is-warm" : ""
+                      }`.trim()}
+                      style={{
+                        height: `${Math.max(8, level * 100)}%`,
+                      }}
                     />
+                  ))}
+                </div>
+                <span
+                  className="level-meter-peak"
+                  style={{ left: `${peakNorm * 100}%` }}
+                />
+              </div>
+              <div className="field-grid-3">
+                <div className="field-row">
+                  <span className="field-label">Current Level</span>
+                  <strong>{monitor.currentDbfs.toFixed(1)} dBFS</strong>
+                </div>
+                <div className="field-row">
+                  <span className="field-label">Peak Level</span>
+                  <strong>{monitor.peakDbfs.toFixed(1)} dBFS</strong>
+                </div>
+                <div className="field-row">
+                  <span className="field-label">SPL Estimate</span>
+                  <strong>{monitor.splEstimate.toFixed(1)} dB SPL</strong>
+                </div>
+              </div>
+              {monitor.clipCount > 0 && (
+                <p className="muted mt-8" style={{ color: "#ff8e8e" }}>
+                  Clipping detected ({monitor.clipCount})
+                </p>
+              )}
+              <div style={{ display: "flex", gap: 8, marginTop: 12, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  className="skin-btn secondary"
+                  onClick={monitor.monitoring ? onStopMonitor : onStartMonitor}
+                >
+                  {monitor.monitoring ? "Stop Monitoring" : "Start Monitoring"}
+                </button>
+                <button
+                  type="button"
+                  className="skin-btn secondary"
+                  disabled={running}
+                  onClick={pinkNoisePlaying ? onStopPinkNoise : onStartPinkNoise}
+                >
+                  {pinkNoisePlaying ? "Stop Pink Noise" : "Play Pink Noise"}
+                </button>
+                <button
+                  type="button"
+                  className="skin-btn secondary"
+                  onClick={onResetPeak}
+                >
+                  Reset Peak
+                </button>
+              </div>
+            </section>
+
+            <section className="page-card live-rough-card">
+              <h3 className="section-subheading">Live Rough FR (Pink Noise)</h3>
+              <p className="muted">
+                {pinkNoisePlaying
+                  ? "Live preview running"
+                  : "Start Pink Noise + Monitoring"}
+              </p>
+              <div className="level-meter live-rough-meter">
+                <svg viewBox="0 0 200 100" className="live-rough-svg">
+                  <line
+                    x1="0"
+                    y1="10"
+                    x2="200"
+                    y2="10"
+                    stroke="var(--level-grid)"
+                    strokeWidth="0.6"
+                  />
+                  <line
+                    x1="0"
+                    y1="50"
+                    x2="200"
+                    y2="50"
+                    stroke="var(--level-grid)"
+                    strokeWidth="1"
+                  />
+                  <line
+                    x1="0"
+                    y1="90"
+                    x2="200"
+                    y2="90"
+                    stroke="var(--level-grid)"
+                    strokeWidth="0.6"
+                  />
+                  {(roughFrGraph?.xGuides ?? []).map((guide) => (
+                    <g key={`guide-${guide.label}-${guide.x.toFixed(2)}`}>
+                      <line
+                        x1={guide.x}
+                        y1="8"
+                        x2={guide.x}
+                        y2="92"
+                        stroke="var(--level-grid)"
+                        strokeWidth="0.45"
+                      />
+                      <text
+                        x={guide.x}
+                        y="98"
+                        textAnchor="middle"
+                        fontSize="7"
+                        fill="var(--text-muted)"
+                      >
+                        {guide.label}
+                      </text>
+                    </g>
+                  ))}
+                  <text x="4" y="12" fontSize="7" fill="var(--text-muted)">
+                    +18 dB
+                  </text>
+                  <text x="4" y="52" fontSize="7" fill="var(--text-muted)">
+                    0 dB
+                  </text>
+                  <text x="4" y="92" fontSize="7" fill="var(--text-muted)">
+                    -18 dB
+                  </text>
+                  {pinkNoisePlaying && roughFrGraph ? (
+                    <>
+                      <path
+                        d={roughFrGraph.areaPath}
+                        fill="var(--accent-dim)"
+                        opacity="0.2"
+                      />
+                      <path
+                        d={roughFrGraph.linePath}
+                        fill="none"
+                        stroke="var(--accent-strong)"
+                        strokeWidth="2"
+                        strokeLinejoin="round"
+                        strokeLinecap="round"
+                      />
+                    </>
+                  ) : (
                     <text
-                      x={guide.x}
-                      y="98"
+                      x="100"
+                      y="54"
                       textAnchor="middle"
-                      fontSize="7"
+                      fontSize="8"
                       fill="var(--text-muted)"
                     >
-                      {guide.label}
+                      Waiting for live data
                     </text>
-                  </g>
-                ))}
-                <text x="4" y="12" fontSize="7" fill="var(--text-muted)">
-                  +18 dB
-                </text>
-                <text x="4" y="52" fontSize="7" fill="var(--text-muted)">
-                  0 dB
-                </text>
-                <text x="4" y="92" fontSize="7" fill="var(--text-muted)">
-                  -18 dB
-                </text>
-                {pinkNoisePlaying && roughFrGraph ? (
-                  <>
-                    <path
-                      d={roughFrGraph.areaPath}
-                      fill="var(--accent-dim)"
-                      opacity="0.2"
-                    />
-                    <path
-                      d={roughFrGraph.linePath}
-                      fill="none"
-                      stroke="var(--accent-strong)"
-                      strokeWidth="2"
-                      strokeLinejoin="round"
-                      strokeLinecap="round"
-                    />
-                  </>
-                ) : (
-                  <text
-                    x="100"
-                    y="54"
-                    textAnchor="middle"
-                    fontSize="8"
-                    fill="var(--text-muted)"
-                  >
-                    Waiting for live data
-                  </text>
-                )}
-              </svg>
-            </div>
-          </section>
-        </div>
+                  )}
+                </svg>
+              </div>
+            </section>
+          </div>
+        </section>
 
-        <section className="page-card" style={{ marginTop: 12 }}>
+        <hr className="section-divider" />
+        <section className="page-section">
           <h3 className="section-subheading">Sweep FR Results</h3>
           <div
             className="scroll-box"
@@ -513,7 +509,7 @@ export function SweepFrPage({
                 : "No sweep result yet. Run Sweep to populate this panel."}
             </pre>
           </div>
-          <div className="row-end" style={{ marginTop: 12 }}>
+          <div className="row-end mt-12">
             <button
               type="button"
               className="skin-btn secondary"


### PR DESCRIPTION
- Sidebar nav buttons replaced with muted link-style items; active state shows left accent border + tinted background instead of gradient button; inactive items are transparent with hover tint
- Sidebar title 34px → 22px, subtitle uppercase small-caps, footer collapses to a single row (status pill + Stop button); Refresh Devices removed from sidebar (still available on Devices page)
- page-card nesting eliminated across all pages — inner sections now use .page-section (no background/border) separated by hr.section-divider
- section-subheading now uppercase label (12px, letter-spaced) to clearly distinguish section labels from page titles
- page-card padding 14px → 20px; field-grid gaps 10px → 12px
- Inline marginTop style props replaced with .mt-8/10/12/16 utilities
- New .action-row and .section-header-row layout helpers
- Sweep FR side-by-side monitor panels intentionally kept as page-card inside field-grid-2 (coordinate visual panels, not form sections)
- Experimental test panels kept as page-card in 2×2 grid (same reason)

https://claude.ai/code/session_01LJf4bxvJQtZPDjvbiSjUft