### PR TITLE
Regenerate aggregate sweep plots after guided mono merge

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -3112,6 +3112,7 @@ fn save_sweep_lr_avg_plot(
 /// Guided mono mode captures each earphone in a separate sweep, so the
 /// per-sweep plots only contain one side. This regenerates the aggregate plots
 /// using the merged left+right curves so both buds are accounted for.
+#[allow(clippy::too_many_arguments)]
 pub fn save_sweep_combined_plots(
     all_path: Option<&Path>,
     avg_all_path: Option<&Path>,

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -3106,6 +3106,40 @@ fn save_sweep_lr_avg_plot(
         .map_err(|err| AudioError::FileExport(format!("sweep write {}: {err}", path.display())))
 }
 
+/// Render the combined "All Sweeps" / "Average of All" / "Left+Right Average"
+/// plots from both sides' curve data.
+///
+/// Guided mono mode captures each earphone in a separate sweep, so the
+/// per-sweep plots only contain one side. This regenerates the aggregate plots
+/// using the merged left+right curves so both buds are accounted for.
+pub fn save_sweep_combined_plots(
+    all_path: Option<&Path>,
+    avg_all_path: Option<&Path>,
+    lr_avg_path: Option<&Path>,
+    freqs: &[f32],
+    all_curves: &[Vec<f32>],
+    avg_all: &[f32],
+    left_avg: &[f32],
+    right_avg: &[f32],
+) -> Result<(), AudioError> {
+    if let Some(path) = all_path {
+        if !all_curves.is_empty() {
+            save_sweep_multi_plot(path, "All Sweeps Frequency Response", freqs, all_curves)?;
+        }
+    }
+    if let Some(path) = avg_all_path {
+        if !avg_all.is_empty() {
+            save_sweep_single_plot(path, "Average of All Frequency Response", freqs, avg_all)?;
+        }
+    }
+    if let Some(path) = lr_avg_path {
+        if !left_avg.is_empty() && !right_avg.is_empty() {
+            save_sweep_lr_avg_plot(path, freqs, left_avg, right_avg)?;
+        }
+    }
+    Ok(())
+}
+
 const ANC_PLOT_Y_MIN: f32 = -40.0;
 const ANC_PLOT_Y_MAX: f32 = 10.0;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -532,6 +532,44 @@ fn write_squiglink_combined(
     audio::write_squiglink_both_file(path, &freqs, &left_db, &right_db).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+fn save_sweep_combined_plots(
+    all_plot_path: Option<String>,
+    avg_all_plot_path: Option<String>,
+    lr_avg_plot_path: Option<String>,
+    freqs: Vec<f32>,
+    all_curves: Vec<Vec<f32>>,
+    avg_all: Vec<f32>,
+    left_avg: Vec<f32>,
+    right_avg: Vec<f32>,
+) -> Result<(), String> {
+    let resolve = |value: &Option<String>| -> Result<Option<std::path::PathBuf>, String> {
+        match value {
+            Some(raw) if !raw.is_empty() => {
+                let path = std::path::Path::new(raw);
+                validate_output_path(path)?;
+                Ok(Some(path.to_path_buf()))
+            }
+            _ => Ok(None),
+        }
+    };
+    let all = resolve(&all_plot_path)?;
+    let avg_all_path = resolve(&avg_all_plot_path)?;
+    let lr_avg = resolve(&lr_avg_plot_path)?;
+    audio::save_sweep_combined_plots(
+        all.as_deref(),
+        avg_all_path.as_deref(),
+        lr_avg.as_deref(),
+        &freqs,
+        &all_curves,
+        &avg_all,
+        &left_avg,
+        &right_avg,
+    )
+    .map_err(|e| e.to_string())
+}
+
 fn main() {
     let app_state = AppState {
         audio: Arc::new(tokio::sync::Mutex::new(AudioEngine::new())),
@@ -571,6 +609,7 @@ fn main() {
             get_runtime_status,
             ensure_output_dir,
             write_squiglink_combined,
+            save_sweep_combined_plots,
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|err| {

--- a/src/ipc/commands.ts
+++ b/src/ipc/commands.ts
@@ -119,6 +119,22 @@ export const writeSquiglinkCombined = (params: {
   rightDb: number[];
 }): Promise<void> => invoke("write_squiglink_combined", params);
 
+/**
+ * Regenerate the aggregate sweep plots (All Sweeps / Average of All /
+ * Left+Right Average) from both sides' curves. Used after a guided mono run
+ * combines two single-side sweeps so the aggregate plots include both buds.
+ */
+export const saveSweepCombinedPlots = (params: {
+  allPlotPath?: string;
+  avgAllPlotPath?: string;
+  lrAvgPlotPath?: string;
+  freqs: number[];
+  allCurves: number[][];
+  avgAll: number[];
+  leftAvg: number[];
+  rightAvg: number[];
+}): Promise<void> => invoke("save_sweep_combined_plots", params);
+
 export const ensureOutputDir = (path: string): Promise<void> =>
   invoke("ensure_output_dir", { path });
 

--- a/src/ui/use-pawdio-lab.ts
+++ b/src/ui/use-pawdio-lab.ts
@@ -1120,13 +1120,67 @@ export function usePawdioLabController() {
           }
         }
 
+        // Each per-side mono sweep only renders its own bud into the aggregate
+        // plots ("All Sweeps", "Average of All", L/R Average), and the naive
+        // file merge keeps just one side. Regenerate them from the merged
+        // left+right curves so both buds are accounted for.
+        let lrAvgPlotPath: string | undefined;
+        const allPlotPath = String(combinedPayload.files?.plot_all ?? "");
+        const avgAllPlotPath = String(
+          combinedPayload.files?.plot_avg_all ?? "",
+        );
+        const combinedFreqs = numberList(combinedPayload.data["freqs"]);
+        const combinedAllCurves = numberCurveList(
+          combinedPayload.data["mag_db_all"],
+        );
+        const combinedAvgAll = numberList(
+          combinedPayload.data["mag_db_avg_all"],
+        );
+        const combinedLeftAvg = numberList(
+          combinedPayload.data["left_mag_db_avg"],
+        );
+        const combinedRightAvg = numberList(
+          combinedPayload.data["right_mag_db_avg"],
+        );
+        const hasLrAvg =
+          combinedLeftAvg.length > 0 && combinedRightAvg.length > 0;
+        if (allPlotPath && hasLrAvg) {
+          lrAvgPlotPath = allPlotPath.replace(
+            "sweep_fr_all_",
+            "sweep_fr_lr_avg_",
+          );
+        }
+        if (combinedFreqs.length && (allPlotPath || avgAllPlotPath)) {
+          await ipc
+            .saveSweepCombinedPlots({
+              allPlotPath: allPlotPath || undefined,
+              avgAllPlotPath: avgAllPlotPath || undefined,
+              lrAvgPlotPath,
+              freqs: combinedFreqs,
+              allCurves: combinedAllCurves,
+              avgAll: combinedAvgAll,
+              leftAvg: combinedLeftAvg,
+              rightAvg: combinedRightAvg,
+            })
+            .catch(logCaughtError("saveSweepCombinedPlots"));
+        } else {
+          lrAvgPlotPath = undefined;
+        }
+
+        const extraFiles: Record<string, string> = {};
+        if (squiglinkBothPath) {
+          extraFiles.squiglink_both = squiglinkBothPath;
+        }
+        if (lrAvgPlotPath) {
+          extraFiles.plot_lr_avg = lrAvgPlotPath;
+        }
         const normalized = {
           ...combinedPayload,
           timestamp: legacyTimestamp(combinedPayload.timestamp),
-          ...(squiglinkBothPath && {
+          ...(Object.keys(extraFiles).length > 0 && {
             files: {
               ...combinedPayload.files,
-              squiglink_both: squiglinkBothPath,
+              ...extraFiles,
             },
           }),
         };

--- a/src/ui/use-pawdio-lab.ts
+++ b/src/ui/use-pawdio-lab.ts
@@ -231,6 +231,27 @@ function numberList(value: unknown): number[] {
     .filter((item) => Number.isFinite(item));
 }
 
+/**
+ * Derive a sibling file path by replacing a token in the final path segment
+ * (basename) only. Returns undefined when the basename does not contain the
+ * token, so callers never fabricate a path from a filename that doesn't match.
+ * Scoping the replacement to the basename avoids clobbering an earlier
+ * directory segment that happens to contain the same token.
+ */
+function siblingPathByBasename(
+  path: string,
+  search: string,
+  replacement: string,
+): string | undefined {
+  const sepIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const dir = sepIndex >= 0 ? path.slice(0, sepIndex + 1) : "";
+  const base = sepIndex >= 0 ? path.slice(sepIndex + 1) : path;
+  if (!base.includes(search)) {
+    return undefined;
+  }
+  return `${dir}${base.replace(search, replacement)}`;
+}
+
 function exportTimestampTag(): string {
   const now = new Date();
   const yyyy = now.getFullYear();
@@ -1144,14 +1165,18 @@ export function usePawdioLabController() {
         );
         const hasLrAvg =
           combinedLeftAvg.length > 0 && combinedRightAvg.length > 0;
+        // Derive the L/R-average path from the basename only so a directory
+        // segment containing "sweep_fr_all_" can't be rewritten by mistake.
         if (allPlotPath && hasLrAvg) {
-          lrAvgPlotPath = allPlotPath.replace(
+          lrAvgPlotPath = siblingPathByBasename(
+            allPlotPath,
             "sweep_fr_all_",
             "sweep_fr_lr_avg_",
           );
         }
+        let combinedPlotsWritten = false;
         if (combinedFreqs.length && (allPlotPath || avgAllPlotPath)) {
-          await ipc
+          combinedPlotsWritten = await ipc
             .saveSweepCombinedPlots({
               allPlotPath: allPlotPath || undefined,
               avgAllPlotPath: avgAllPlotPath || undefined,
@@ -1162,16 +1187,19 @@ export function usePawdioLabController() {
               leftAvg: combinedLeftAvg,
               rightAvg: combinedRightAvg,
             })
-            .catch(logCaughtError("saveSweepCombinedPlots"));
-        } else {
-          lrAvgPlotPath = undefined;
+            .then(() => true)
+            .catch((err) => {
+              logCaughtError("saveSweepCombinedPlots")(err);
+              return false;
+            });
         }
 
         const extraFiles: Record<string, string> = {};
         if (squiglinkBothPath) {
           extraFiles.squiglink_both = squiglinkBothPath;
         }
-        if (lrAvgPlotPath) {
+        // Only record the L/R-average plot once it was actually written.
+        if (lrAvgPlotPath && combinedPlotsWritten) {
           extraFiles.plot_lr_avg = lrAvgPlotPath;
         }
         const normalized = {


### PR DESCRIPTION
## Summary

When guided mono mode captures both earphones in separate sweeps, the per-sweep aggregate plots ("All Sweeps", "Average of All", "Left+Right Average") only contain data from one side. After merging the left and right curves, regenerate these plots so both buds are accounted for in the final output.

## Changes

- **Frontend (`use-pawdio-lab.ts`)**: After combining left and right sweep payloads, extract the merged frequency and curve data, then invoke a new `saveSweepCombinedPlots` IPC command to regenerate the aggregate plots. Also refactor the extra files logic to use a dictionary for cleaner extensibility.

- **IPC boundary (`ipc/commands.ts`)**: Add `saveSweepCombinedPlots` command wrapper that accepts paths and curve data for all three aggregate plot types.

- **Tauri command handler (`main.rs`)**: Register new `save_sweep_combined_plots` command that validates output paths and delegates to the audio module.

- **Audio module (`audio/mod.rs`)**: Implement `save_sweep_combined_plots` function that conditionally renders each aggregate plot type (all curves, average of all, left+right average) using existing plot generation utilities.

## Implementation Details

- The regeneration only occurs if both left and right average curves are present (indicating a successful guided mono merge).
- The left+right average plot path is derived by replacing `"sweep_fr_all_"` with `"sweep_fr_lr_avg_"` in the all-sweeps plot path.
- Each plot is only written if its corresponding path is provided and the data is non-empty, reusing existing `save_sweep_single_plot` and `save_sweep_multi_plot` utilities.

https://claude.ai/code/session_016gRxneDo6HSzNHCyF2uBLX