### PR TITLE
Fix Rust CI: rustfmt db.rs, clippy io_other_error, Cargo.lock update

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +856,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1404,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1392,6 +1425,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1919,6 +1961,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,6 +2481,7 @@ dependencies = [
  "num-complex",
  "plotters",
  "rand 0.8.5",
+ "rusqlite",
  "rustfft",
  "serde",
  "serde_json",
@@ -3027,6 +3081,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4307,6 +4375,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -118,9 +118,7 @@ pub fn list_devices(conn: &Connection) -> Result<Vec<DeviceRecord>, String> {
     let mut stmt = conn
         .prepare("SELECT id, name, kind, notes, created_at FROM devices ORDER BY created_at DESC, id DESC")
         .map_err(|e| e.to_string())?;
-    let rows = stmt
-        .query_map([], map_device)
-        .map_err(|e| e.to_string())?;
+    let rows = stmt.query_map([], map_device).map_err(|e| e.to_string())?;
     let mut out = Vec::new();
     for row in rows {
         out.push(row.map_err(|e| e.to_string())?);
@@ -191,8 +189,9 @@ pub fn list_measurements(
     device_id: Option<i64>,
     test_type: Option<String>,
 ) -> Result<Vec<MeasurementSummary>, String> {
-    let mut sql =
-        String::from("SELECT id, device_id, test_type, captured_at, label FROM measurements WHERE 1=1");
+    let mut sql = String::from(
+        "SELECT id, device_id, test_type, captured_at, label FROM measurements WHERE 1=1",
+    );
     let mut binds: Vec<SqlValue> = Vec::new();
     if let Some(d) = device_id {
         sql.push_str(" AND device_id = ?");
@@ -275,7 +274,14 @@ pub fn save_measurement(
         "INSERT INTO measurements
             (device_id, test_type, captured_at, label, notes, payload_json, schema_ver)
          VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6)",
-        params![device_id, test_type, captured_at, label, payload_json, DB_VERSION],
+        params![
+            device_id,
+            test_type,
+            captured_at,
+            label,
+            payload_json,
+            DB_VERSION
+        ],
     )
     .map_err(|e| e.to_string())?;
     Ok(MeasurementRecord {
@@ -313,7 +319,8 @@ mod tests {
         assert!(dev.id > 0);
 
         let payload = serde_json::json!({ "test": "latency", "averageDelayMs": 12.5 });
-        let rec = save_measurement(&conn, dev.id, "latency", Some("run 1".into()), &payload).unwrap();
+        let rec =
+            save_measurement(&conn, dev.id, "latency", Some("run 1".into()), &payload).unwrap();
         assert_eq!(rec.device_id, dev.id);
 
         let summaries = list_measurements(&conn, Some(dev.id), None).unwrap();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -651,15 +651,9 @@ fn main() {
             let db_path = app
                 .path()
                 .app_data_dir()
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("could not resolve app data dir: {e}"),
-                    )
-                })?
+                .map_err(|e| std::io::Error::other(format!("could not resolve app data dir: {e}")))?
                 .join("pawdio-lab.db");
-            let conn = db::init(&db_path)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let conn = db::init(&db_path).map_err(std::io::Error::other)?;
 
             app.manage(AppState {
                 audio: Arc::new(tokio::sync::Mutex::new(AudioEngine::new())),


### PR DESCRIPTION
Fixes the failing `Rust (fmt / clippy / test)` CI check on `main` (first seen on #46, but pre-existing — introduced by the earlier database feature commit).

## What was failing
1. **`cargo fmt --check`** failed on `src-tauri/src/db.rs` (4 unformatted blocks), aborting the job before clippy/tests ran.
2. Once past fmt, **`cargo clippy -- -D warnings`** would fail next on two `clippy::io_other_error` lints in `src-tauri/src/main.rs`.
3. `Cargo.lock` was missing entries for the `rusqlite` dependency tree.

## Changes
- Ran `rustfmt` on `src-tauri/src/db.rs`
- Replaced `std::io::Error::new(ErrorKind::Other, …)` with `std::io::Error::other(…)` (2 sites in `main.rs`)
- Updated `src-tauri/Cargo.lock`

## Verification
Ran the exact CI steps locally:
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` — 8 passed ✅

https://claude.ai/code/session_01Mwwq2CTDc2eVtCwy9PCNmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwwq2CTDc2eVtCwy9PCNmJ)_